### PR TITLE
Added executor and spinning

### DIFF
--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.cpp
@@ -59,12 +59,15 @@ namespace ROS2
         {
             ROS2Interface::Unregister(this);
         }
+        rclcpp::shutdown();
     }
 
     void ROS2SystemComponent::Init()
     {
         rclcpp::init(0, 0);
         ros2_node = std::make_shared<rclcpp::Node>("o3de_ros2_node");
+        executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+        executor->add_node(ros2_node);
     }
 
     void ROS2SystemComponent::Activate()
@@ -86,6 +89,13 @@ namespace ROS2
 
     void ROS2SystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        simulation_clock.Tick();
+        if (rclcpp::ok())
+        {
+            simulation_clock.Tick();
+
+            //TODO - this can be in another thread and done with a higher resolution for less latency.
+            //TODO - callbacks will be called in the spinning thread (here, the main thread).
+            executor->spin_some();
+        }
     }
 } // namespace ROS2

--- a/Gems/ROS2/Code/Source/ROS2SystemComponent.h
+++ b/Gems/ROS2/Code/Source/ROS2SystemComponent.h
@@ -6,7 +6,7 @@
 #include <ROS2/ROS2Bus.h>
 
 #include <memory>
-#include "rclcpp/node.hpp"
+#include "rclcpp/rclcpp.hpp"
 #include "builtin_interfaces/msg/time.hpp"
 #include "SimulationClock.h"
 
@@ -53,6 +53,7 @@ namespace ROS2
     
     private:
         std::shared_ptr<rclcpp::Node> ros2_node;
+        std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor;
         SimulationClock simulation_clock;
     };
 


### PR DESCRIPTION
- subscriptions to central sim node can now have their callbacks called
- executor spins in onTick(), but can be moved to a separate thread as needed.

Signed-off-by: Adam Dabrowski <adam.dabrowski@robotec.ai>