### PR TITLE
URDF parser with tests

### DIFF
--- a/Gems/ROS2/Code/CMakeLists.txt
+++ b/Gems/ROS2/Code/CMakeLists.txt
@@ -38,7 +38,7 @@ ly_add_target(
             AZ::AzFramework
 )
 
-target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs)
+target_depends_on_ros2_packages(ROS2.Static rclcpp builtin_interfaces std_msgs sensor_msgs urdfdom)
 
 #TODO - export version/distro info to detect conflict (Gem built with ros X but trying to build Project with ros Y),
 #TODO - check within Project build whether there is a match

--- a/Gems/ROS2/Code/Source/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/UrdfParser.cpp
@@ -11,7 +11,7 @@
 #include <fstream>
 #include <string>
 
-#include "urdf_model/model.h"
+#include <urdf_model/model.h>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/UrdfParser.cpp
+++ b/Gems/ROS2/Code/Source/UrdfParser.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <UrdfParser.h>
+
+#include <fstream>
+#include <string>
+
+#include "urdf_model/model.h"
+
+namespace ROS2
+{
+    urdf::ModelInterfaceSharedPtr UrdfParser::Parse(const std::string & xmlString)
+    {
+        return urdf::parseURDF(xmlString);
+    }
+
+    urdf::ModelInterfaceSharedPtr UrdfParser::ParseFromFile(const std::string & filePath)
+    {
+        std::ifstream istream(filePath);
+        if (!istream)
+        {
+          AZ_Error("UrdfParser", false, "File %s not exist", filePath.c_str());
+          return urdf::ModelInterfaceSharedPtr();
+        }
+
+        std::string xmlStr((std::istreambuf_iterator<char>(istream)), std::istreambuf_iterator<char>());
+
+        return Parse(xmlStr);
+    }
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/UrdfParser.h
@@ -8,11 +8,9 @@
 
 #pragma once
 
-#include <cmath>
 #include <string>
-#include <vector>
 
-#include "urdf_parser/urdf_parser.h"
+#include <urdf_parser/urdf_parser.h>
 
 namespace ROS2
 {

--- a/Gems/ROS2/Code/Source/UrdfParser.h
+++ b/Gems/ROS2/Code/Source/UrdfParser.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "urdf_parser/urdf_parser.h"
+
+namespace ROS2
+{
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    //! Class for parsing URDF data
+    class UrdfParser
+    {
+        public:
+            //! Parse string with URDF data and generate model
+            static urdf::ModelInterfaceSharedPtr Parse(const std::string & xmlString);
+
+            //! Parse file with URDF data and generate model
+            static urdf::ModelInterfaceSharedPtr ParseFromFile(const std::string & filePath);
+    };
+
+} // namespace ROS2

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -18,25 +18,64 @@ class UrdfParserTest : public ::testing::Test
         std::string GetUrdfWithOneLink()
         {
             std::string xmlStr =
-            "<robot name=\"test\">"
-            "  <link name=\"link1\">"
-            "    <inertial>"
-            "      <mass value=\"1.0\"/>"
-            "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
-            "    </inertial>"
-            "    <visual>"
-            "      <geometry>"
-            "        <box size=\"1.0 2.0 1.0\"/>"
-            "      </geometry>"
-            "    </visual>"
-            "    <collision>"
-            "      <geometry>"
-            "        <box size=\"1.0 2.0 1.0\"/>"
-            "      </geometry>"
-            "    </collision>"
-            "  </link>"
-            "</robot>";
+                "<robot name=\"test_one_link\">"
+                "  <link name=\"link1\">"
+                "    <inertial>"
+                "      <mass value=\"1.0\"/>"
+                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+                "    </inertial>"
+                "    <visual>"
+                "      <geometry>"
+                "        <box size=\"1.0 2.0 1.0\"/>"
+                "      </geometry>"
+                "      <material name=\"black\"/>"
+                "    </visual>"
+                "    <collision>"
+                "      <geometry>"
+                "        <box size=\"1.0 2.0 1.0\"/>"
+                "      </geometry>"
+                "    </collision>"
+                "  </link>"
+                "</robot>";
+            return xmlStr;
+        }
 
+        std::string GetUrdfWithTwoLinksAndJoint()
+        {
+            std::string xmlStr =
+                "<robot name=\"test_two_links_one_joint\">"
+                "  <link name=\"link1\">"
+                "    <inertial>"
+                "      <mass value=\"1.0\"/>"
+                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+                "    </inertial>"
+                "    <visual>"
+                "      <geometry>"
+                "        <box size=\"1.0 2.0 1.0\"/>"
+                "      </geometry>"
+                "      <material name=\"black\"/>"
+                "    </visual>"
+                "  </link>"
+                "  <link name=\"link2\">"
+                "    <inertial>"
+                "      <mass value=\"1.0\"/>"
+                "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+                "    </inertial>"
+                "    <visual>"
+                "      <geometry>"
+                "        <box size=\"1.0 1.0 1.0\"/>"
+                "      </geometry>"
+                "      <material name=\"black\"/>"
+                "    </visual>"
+                "  </link>"
+                "  <joint name=\"joint12\" type=\"fixed\">"
+                "    <parent link=\"link1\"/>"
+                "    <child link=\"link2\"/>"
+                "    <origin rpy=\"0 0 0\" xyz=\"1.0 0.5 0.0\"/>"
+                "    <dynamics damping=\"10.0\" friction=\"5.0\"/>"
+                "    <limit lower=\"10.0\" upper=\"20.0\" effort=\"90.0\" velocity=\"10.0\"/>"
+                "  </joint>"
+                "</robot>";
             return xmlStr;
         }
     protected:
@@ -48,7 +87,7 @@ TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
     const auto xmlStr = GetUrdfWithOneLink();
     const auto urdf = parser.Parse(xmlStr);
 
-    EXPECT_EQ(urdf->getName(), "test");
+    EXPECT_EQ(urdf->getName(), "test_one_link");
 
     std::vector<urdf::LinkSharedPtr> links;
     urdf->getLinks(links);
@@ -56,6 +95,7 @@ TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
 
     const auto link1 = urdf->getLink("link1");
 
+    ASSERT_TRUE(link1);
     EXPECT_EQ(link1->inertial->mass, 1.0);
     EXPECT_EQ(link1->inertial->ixx, 1.0);
     EXPECT_EQ(link1->inertial->ixy, 0.0);
@@ -64,6 +104,7 @@ TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
     EXPECT_EQ(link1->inertial->iyz, 0.0);
     EXPECT_EQ(link1->inertial->izz, 1.0);
 
+    EXPECT_EQ(link1->visual->material->name, "black");
     EXPECT_EQ(link1->visual->geometry->type, 1);
     const auto visualBox = std::dynamic_pointer_cast<urdf::Box>(link1->visual->geometry);
     EXPECT_EQ(visualBox->dim.x, 1.0);
@@ -75,6 +116,48 @@ TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
     EXPECT_EQ(collisionBox->dim.x, 1.0);
     EXPECT_EQ(collisionBox->dim.y, 2.0);
     EXPECT_EQ(collisionBox->dim.z, 1.0);
+}
+
+TEST_F(UrdfParserTest, ParseUrdfWithTwoLinksAndJoint)
+{
+    const auto xmlStr = GetUrdfWithTwoLinksAndJoint();
+    const auto urdf = parser.Parse(xmlStr);
+
+    EXPECT_EQ(urdf->getName(), "test_two_links_one_joint");
+
+    std::vector<urdf::LinkSharedPtr> links;
+    urdf->getLinks(links);
+    EXPECT_EQ(links.size(), 2U);
+
+    const auto link1 = urdf->getLink("link1");
+    ASSERT_TRUE(link1);
+
+    const auto link2 = urdf->getLink("link2");
+    ASSERT_TRUE(link2);
+
+    const auto joint12 = urdf->getJoint("joint12");
+    ASSERT_TRUE(joint12);
+
+    EXPECT_EQ(joint12->parent_link_name, "link1");
+    EXPECT_EQ(joint12->child_link_name, "link2");
+
+    EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.x, 1.0);
+    EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.y, 0.5);
+    EXPECT_EQ(joint12->parent_to_joint_origin_transform.position.z, 0.0);
+
+    double roll, pitch, yaw;
+    joint12->parent_to_joint_origin_transform.rotation.getRPY(roll, pitch, yaw);
+    EXPECT_DOUBLE_EQ(roll, 0.0);
+    EXPECT_DOUBLE_EQ(pitch, 0.0);
+    EXPECT_DOUBLE_EQ(yaw, 0.0);
+
+    EXPECT_EQ(joint12->dynamics->damping, 10.0);
+    EXPECT_EQ(joint12->dynamics->friction, 5.0);
+
+    EXPECT_EQ(joint12->limits->lower, 10.0);
+    EXPECT_EQ(joint12->limits->upper, 20.0);
+    EXPECT_EQ(joint12->limits->effort, 90.0);
+    EXPECT_EQ(joint12->limits->velocity, 10.0);
 }
 
 } // namespace

--- a/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
+++ b/Gems/ROS2/Code/Tests/UrdfParserTest.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <UrdfParser.h>
+
+#include <AzTest/AzTest.h>
+
+namespace {
+
+class UrdfParserTest : public ::testing::Test
+{
+    public:
+        std::string GetUrdfWithOneLink()
+        {
+            std::string xmlStr =
+            "<robot name=\"test\">"
+            "  <link name=\"link1\">"
+            "    <inertial>"
+            "      <mass value=\"1.0\"/>"
+            "      <inertia ixx=\"1.0\" iyy=\"1.0\" izz=\"1.0\" ixy=\"0\" ixz=\"0\" iyz=\"0\"/>"
+            "    </inertial>"
+            "    <visual>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "    </visual>"
+            "    <collision>"
+            "      <geometry>"
+            "        <box size=\"1.0 2.0 1.0\"/>"
+            "      </geometry>"
+            "    </collision>"
+            "  </link>"
+            "</robot>";
+
+            return xmlStr;
+        }
+    protected:
+        ROS2::UrdfParser parser; 
+};
+
+TEST_F(UrdfParserTest, ParseUrdfWithOneLink)
+{
+    const auto xmlStr = GetUrdfWithOneLink();
+    const auto urdf = parser.Parse(xmlStr);
+
+    EXPECT_EQ(urdf->getName(), "test");
+
+    std::vector<urdf::LinkSharedPtr> links;
+    urdf->getLinks(links);
+    EXPECT_EQ(links.size(), 1U);
+
+    const auto link1 = urdf->getLink("link1");
+
+    EXPECT_EQ(link1->inertial->mass, 1.0);
+    EXPECT_EQ(link1->inertial->ixx, 1.0);
+    EXPECT_EQ(link1->inertial->ixy, 0.0);
+    EXPECT_EQ(link1->inertial->ixz, 0.0);
+    EXPECT_EQ(link1->inertial->iyy, 1.0);
+    EXPECT_EQ(link1->inertial->iyz, 0.0);
+    EXPECT_EQ(link1->inertial->izz, 1.0);
+
+    EXPECT_EQ(link1->visual->geometry->type, 1);
+    const auto visualBox = std::dynamic_pointer_cast<urdf::Box>(link1->visual->geometry);
+    EXPECT_EQ(visualBox->dim.x, 1.0);
+    EXPECT_EQ(visualBox->dim.y, 2.0);
+    EXPECT_EQ(visualBox->dim.z, 1.0);
+
+    EXPECT_EQ(link1->collision->geometry->type, 1);
+    const auto collisionBox = std::dynamic_pointer_cast<urdf::Box>(link1->visual->geometry);
+    EXPECT_EQ(collisionBox->dim.x, 1.0);
+    EXPECT_EQ(collisionBox->dim.y, 2.0);
+    EXPECT_EQ(collisionBox->dim.z, 1.0);
+}
+
+} // namespace

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     Source/ROS2SystemComponent.h
     Source/Clock/SimulationClock.cpp
     Source/Clock/SimulationClock.h
+    Source/UrdfParser.cpp
+    Source/UrdfParser.h
 )

--- a/Gems/ROS2/Code/ros2_tests_files.cmake
+++ b/Gems/ROS2/Code/ros2_tests_files.cmake
@@ -1,4 +1,5 @@
 
 set(FILES
     Tests/ROS2Test.cpp
+    Tests/UrdfParserTest.cpp
 )


### PR DESCRIPTION
It's related to the issue [#8483](https://github.com/o3de/o3de/issues/8483).

Unit tests

- Compile specific test module (example with ROS2.Tests)
  `cmake --build build/linux --target ROS2.Tests --config profile -j 4`
- Run specific tests
  `build/linux/bin/profile/AzTestRunner libROS2.Tests.so AzRunUnitTests --gtest_filter=*`
