### PR TITLE
Sensor abstraction

### DIFF
--- a/Gems/ROS2/Code/Source/Clock/SimulationClock.cpp
+++ b/Gems/ROS2/Code/Source/Clock/SimulationClock.cpp
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
+#include "ROS2/ROS2Bus.h"
 #include "SimulationClock.h"
 #include <rclcpp/qos.hpp>
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -26,7 +26,7 @@ namespace ROS2
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2LidarSensorComponent, ROS2SensorComponent>("Lidar Sensor", "[Simple Lidar component]")
+                ec->Class<ROS2LidarSensorComponent>("Lidar Sensor", "[Simple Lidar component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Simulation"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")
@@ -68,7 +68,7 @@ namespace ROS2
         //AZ_TracePrintf("Lidar Sensor Component", "Raycast done, results ready");
 
         auto message = sensor_msgs::msg::PointCloud2();
-        message.header.frame_id = GetConfiguration().GetFrameId().data();
+        message.header.frame_id = GetConfiguration().GetFrameID().data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
         message.height = 1;
         message.width = results.size();

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -15,71 +15,48 @@
 
 namespace ROS2
 {
-    void ROS2LidarSensorComponent::Init()
-    {
-        auto ros2Node = ROS2Interface::Get()->GetNode();
-        m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>("point_cloud", 10);
-    }
-
-    void ROS2LidarSensorComponent::Activate()
-    {
-        // TODO - add range validation (Attributes?)
-        m_frameTime = m_hz == 0 ? 1 : 1 / m_hz;
-        AZ::TickBus::Handler::BusConnect();
-        m_entityTransform = GetEntity()->FindComponent<AzFramework::TransformComponent>();
-    }
-
-    void ROS2LidarSensorComponent::Deactivate()
-    {
-        AZ::TickBus::Handler::BusDisconnect();
-    }
-
     void ROS2LidarSensorComponent::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2LidarSensorComponent, AZ::Component>()
+            serialize->Class<ROS2LidarSensorComponent, ROS2SensorComponent>()
                 ->Version(1)
-                ->Field("hz", &ROS2LidarSensorComponent::m_hz)
-                ->Field("frameName", &ROS2LidarSensorComponent::m_frameName)
                 ->Field("lidarModel", &ROS2LidarSensorComponent::m_lidarModel)
                 ;
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
-                ec->Class<ROS2LidarSensorComponent>("Lidar Sensor", "[Simple Lidar component]")
+                ec->Class<ROS2LidarSensorComponent, ROS2SensorComponent>("Lidar Sensor", "[Simple Lidar component]")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game")) // TODO - "Simulation"?
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_hz, "Hz", "Lidar data acquisition and publish frequency")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_frameName, "Frame Name", "Lidar ros2 message frame")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Simulation"))
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2LidarSensorComponent::m_lidarModel, "Lidar Model", "Lidar model")
                     ;
             }
         }
     }
 
-    void ROS2LidarSensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    void ROS2LidarSensorComponent::Activate()
     {
-        required.push_back(AZ_CRC("TransformService"));
+        ROS2SensorComponent::Activate();
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+        auto config = GetConfiguration();
+
+        // TODO - also use QoS
+        m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(config.m_publishTopic.data(), 10);
     }
 
-    void ROS2LidarSensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    void ROS2LidarSensorComponent::Deactivate()
     {
-        static float elapsed = 0;
-        elapsed += deltaTime;
-        if (elapsed < m_frameTime)
-            return;
+        ROS2SensorComponent::Deactivate();
+        m_pointCloudPublisher.reset();
+    }
 
-        elapsed -= m_frameTime;
-        if (deltaTime > m_frameTime)
-        {   // Frequency higher than possible, not catching up, just keep going with each frame.
-            elapsed = 0;
-        }
-
-        ;
+    void ROS2LidarSensorComponent::FrequencyTick()
+    {
         float distance = LidarTemplateUtils::GetTemplate(m_lidarModel).m_maxRange;
         const auto directions = LidarTemplateUtils::PopulateRayDirections(m_lidarModel);
-        AZ::Vector3 start = m_entityTransform->GetWorldTM().GetTranslation();
+        auto entityTransform = GetEntity()->FindComponent<AzFramework::TransformComponent>();
+        AZ::Vector3 start = entityTransform->GetWorldTM().GetTranslation();
         start.SetZ(start.GetZ() + 1.0f);
         AZStd::vector<AZ::Vector3> results = m_lidarRaycaster.PerformRaycast(start, directions, distance);
 

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.cpp
@@ -42,7 +42,7 @@ namespace ROS2
         auto config = GetConfiguration();
 
         // TODO - also use QoS
-        m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(config.m_publishTopic.data(), 10);
+        m_pointCloudPublisher = ros2Node->create_publisher<sensor_msgs::msg::PointCloud2>(config.GetTopic().data(), 10);
     }
 
     void ROS2LidarSensorComponent::Deactivate()
@@ -68,7 +68,7 @@ namespace ROS2
         //AZ_TracePrintf("Lidar Sensor Component", "Raycast done, results ready");
 
         auto message = sensor_msgs::msg::PointCloud2();
-        message.header.frame_id = m_frameName.data();
+        message.header.frame_id = GetConfiguration().GetFrameId().data();
         message.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
         message.height = 1;
         message.width = results.size();

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -7,8 +7,10 @@
  */
 #pragma once
 
+#include <rclcpp/publisher.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
 #include <AzCore/Component/Component.h>
-#include <AzCore/std/smart_ptr/make_unique.h>
 #include <AzFramework/Components/TransformComponent.h>
 
 #include "Sensor/ROS2SensorComponent.h"
@@ -29,7 +31,8 @@ namespace ROS2
 
     private:
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::SickMRS6000;
-
+        LidarRaycaster m_lidarRaycaster;
+        rclcpp::Publisher<sensor_msgs::msg::PointCloud2> m_pointCloudPublisher;
         // TODO - also add a data acquisition implementation choice (and consider propagating abstraction upwards)
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -8,46 +8,28 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/std/smart_ptr/make_unique.h>
 #include <AzFramework/Components/TransformComponent.h>
 
-#include <memory>
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/point_cloud2.hpp"
-
+#include "Sensor/ROS2SensorComponent.h"
 #include "Lidar/LidarTemplate.h"
-#include "Lidar/LidarRaycaster.h"
 
 namespace ROS2
 {
     class ROS2LidarSensorComponent
-        : public AZ::Component
-        , public AZ::TickBus::Handler
+        : public ROS2SensorComponent
     {
     public:
-        AZ_COMPONENT(ROS2LidarSensorComponent, "{502A955F-7742-4E23-AD77-5E4063739DCA}", AZ::Component);
-
-        // AZ::Component interface implementation.
-        void Init() override;
+        AZ_COMPONENT(ROS2LidarSensorComponent, "{502A955F-7742-4E23-AD77-5E4063739DCA}", ROS2SensorComponent);
+        ROS2LidarSensorComponent() = default;
+        void ~ROS2LidarSensorComponent() = default;
+        static void Reflect(AZ::ReflectContext* context);
         void Activate() override;
         void Deactivate() override;
 
-        // Required Reflect function.
-        static void Reflect(AZ::ReflectContext* context);
-
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-        // Optional functions for defining provided and dependent services.
-        // static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
-        // static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
-        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-        // static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
-
     private:
-        AZStd::string m_frameName = "test_lidar";
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::SickMRS6000;
-        float m_hz = 10;
-        float m_frameTime;
-        LidarRaycaster m_lidarRaycaster;
-        rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr m_pointCloudPublisher;
-        AzFramework::TransformComponent* m_entityTransform;
+
+        // TODO - also add a data acquisition implementation choice (and consider propagating abstraction upwards)
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
+++ b/Gems/ROS2/Code/Source/Lidar/ROS2LidarSensorComponent.h
@@ -23,16 +23,16 @@ namespace ROS2
     {
     public:
         AZ_COMPONENT(ROS2LidarSensorComponent, "{502A955F-7742-4E23-AD77-5E4063739DCA}", ROS2SensorComponent);
-        ROS2LidarSensorComponent() = default;
-        void ~ROS2LidarSensorComponent() = default;
         static void Reflect(AZ::ReflectContext* context);
         void Activate() override;
         void Deactivate() override;
 
     private:
+        void FrequencyTick() override;
+
         LidarTemplate::LidarModel m_lidarModel = LidarTemplate::SickMRS6000;
         LidarRaycaster m_lidarRaycaster;
-        rclcpp::Publisher<sensor_msgs::msg::PointCloud2> m_pointCloudPublisher;
+        std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::PointCloud2>> m_pointCloudPublisher;
         // TODO - also add a data acquisition implementation choice (and consider propagating abstraction upwards)
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -10,30 +10,17 @@
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/smart_ptr/make_unique.h>
 
 namespace ROS2
 {
-    void ROSSensorComponent::Init()
-    {
-    }
-
     void ROS2SensorComponent::Activate()
     {
         AZ::TickBus::Handler::BusConnect();
-
-        if (m_publishTransform)
-        {
-            auto ros2Node = ROS2Interface::Get()->GetNode();
-            m_staticTransformPublisher = AZStd::make_unique<ROS2StaticTransformPublisher>(ros2Node, transform);
-        }
     }
 
     void ROS2SensorComponent::Deactivate()
     {
         AZ::TickBus::Handler::BusDisconnect();
-        m_ros2Sensor.reset();
-        m_transformPublisher.reset();
     }
 
     void ROS2SensorComponent::Reflect(AZ::ReflectContext* context)

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include "Sensor/ROS2SensorComponent.h"
 #include "ROS2/ROS2Bus.h"
-#include "ROS2SensorComponent.h"
+#include "Utilities/ROS2Names.h"
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -39,12 +40,29 @@ namespace ROS2
         return m_sensorConfiguration;
     }
 
-    void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    AZStd::string ROS2SensorComponent::GetNamespace() const
     {
-        required.push_back(AZ_CRC("TransformService")); //TODO - requires ROS2Frame service
+        // TODO - hold frame?
+        auto ros2Frame = GetEntity()->FindComponent<ROS2FrameComponent>();
+        return ros2Frame->GetNamespace();
+    };
+
+    AZStd::string ROS2SensorComponent::GetFullTopic() const
+    {
+        return ROS2Names::GetNamespacedName(GetNamespace(), m_sensorConfiguration.m_topic);
     }
 
-    void ROSSensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    AZStd::string ROS2SensorComponent::GetFrameID() const
+    {
+        return ROS2Names::GetNamespacedName(GetNamespace(), m_sensorConfiguration.m_topic);
+    }
+
+    void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("ROS2Frame"));
+    }
+
+    void ROS2SensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         auto hz = m_sensorConfiguration.m_hz;
 

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "ROS2/ROS2Bus.h"
+#include "ROS2SensorComponent.h"
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/smart_ptr/make_unique.h>
+
+namespace ROS2
+{
+    void ROSSensorComponent::Init()
+    {
+    }
+
+    void ROS2SensorComponent::Activate()
+    {
+        AZ::TickBus::Handler::BusConnect();
+
+
+        if (m_publishTransform)
+        {
+            auto ros2Node = ROS2Interface::Get()->GetNode();
+            m_staticTransformPublisher = AZStd::make_unique<ROS2StaticTransformPublisher>(ros2Node, transform);
+        }
+    }
+
+    void ROS2SensorComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+        m_ros2Sensor.reset();
+        m_transformPublisher.reset();
+    }
+
+    void ROS2SensorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2SensorComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("SensorConfiguration", &ROS2SensorComponent::m_sensorConfiguration)
+                ;
+        }
+    }
+
+    const SensorConfiguration& ROS2SensorComponent::GetConfiguration() const
+    {
+        return m_sensorConfiguration;
+    }
+
+    void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("TransformService"));
+    }
+
+    void ROSSensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        auto hz = m_sensorConfiguration.m_hz;
+
+        // TODO - add range validation (Attributes?)
+        auto frameTime = hz == 0 ? 1 : 1 / hz;
+
+        static float elapsed = 0;
+        elapsed += deltaTime;
+        if (elapsed < frameTime)
+            return;
+
+        elapsed -= frameTime;
+        if (deltaTime > frameTime)
+        {   // Frequency higher than possible, not catching up, just keep going with each frame.
+            elapsed = 0;
+        }
+
+        // Note that sensor frequency can be limited by simulation tick rate (if higher sensor Hz is desired).
+        FrequencyTick();
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.cpp
@@ -22,7 +22,6 @@ namespace ROS2
     {
         AZ::TickBus::Handler::BusConnect();
 
-
         if (m_publishTransform)
         {
             auto ros2Node = ROS2Interface::Get()->GetNode();
@@ -55,7 +54,7 @@ namespace ROS2
 
     void ROS2SensorComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        required.push_back(AZ_CRC("TransformService"));
+        required.push_back(AZ_CRC("TransformService")); //TODO - requires ROS2Frame service
     }
 
     void ROSSensorComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include "SensorConfiguration.h"
 
 namespace ROS2
@@ -19,11 +21,10 @@ namespace ROS2
     {
     public:
         ROS2SensorComponent() = default;
-        virtual void ~ROS2SensorComponent() = default;
+        virtual ~ROS2SensorComponent() = default;
         AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}", AZ::Component);
 
         // AZ::Component interface implementation.
-        void Init() override;
         void Activate() override;
         void Deactivate() override;
 
@@ -40,6 +41,5 @@ namespace ROS2
 
         // TODO - Editor component: validation of fields, constraints between values and so on
         SensorConfiguration m_sensorConfiguration;
-        AZStd::unique_ptr<ROS2StaticTransformPublisher> m_staticTransformPublisher;
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
@@ -34,10 +34,16 @@ namespace ROS2
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
     protected:
+        // Getters which include namespaces
+        AZStd::string GetFullTopic() const;
+        AZStd::string GetFrameID() const;
+
         const SensorConfiguration& GetConfiguration() const;
 
     private:
-        virtual void FrequencyTick() = 0; // Override to implement sensor behavior
+        AZStd::string GetNamespace() const;
+
+        virtual void FrequencyTick() { }; // Override to implement sensor behavior
 
         // TODO - Editor component: validation of fields, constraints between values and so on
         SensorConfiguration m_sensorConfiguration;

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+
+namespace ROS2
+{
+    /// Captures common behavior of ROS2 sensor components. Derive to implement ROS2 sensors
+    class ROS2SensorComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler // TODO - high resolution tick source?
+    {
+    public:
+        AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}", AZ::Component);
+
+        // AZ::Component interface implementation.
+        void Init() override;
+        void Activate() override;
+        void Deactivate() override;
+
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+    protected:
+        const SensorConfiguration& GetConfiguration() const;
+
+    private:
+        virtual void CreatePipeline() = 0; // Create data acquisition, publishing pipeline
+        virtual void FrequencyTick() = 0; // Override to implement sensor behavior
+
+        SensorConfiguration m_sensorConfiguration;
+        AZStd::unique_ptr<ROS2SensorBase> m_ros2Sensor;
+        AZStd::unique_ptr<ROS2StaticTransformPublisher> m_staticTransformPublisher;
+    };
+}  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
+++ b/Gems/ROS2/Code/Source/Sensor/ROS2SensorComponent.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
+#include "SensorConfiguration.h"
 
 namespace ROS2
 {
@@ -17,6 +18,8 @@ namespace ROS2
         , public AZ::TickBus::Handler // TODO - high resolution tick source?
     {
     public:
+        ROS2SensorComponent() = default;
+        virtual void ~ROS2SensorComponent() = default;
         AZ_COMPONENT(ROS2SensorComponent, "{91BCC1E9-6D93-4466-9CDB-E73D497C6B5E}", AZ::Component);
 
         // AZ::Component interface implementation.
@@ -33,11 +36,10 @@ namespace ROS2
         const SensorConfiguration& GetConfiguration() const;
 
     private:
-        virtual void CreatePipeline() = 0; // Create data acquisition, publishing pipeline
         virtual void FrequencyTick() = 0; // Override to implement sensor behavior
 
+        // TODO - Editor component: validation of fields, constraints between values and so on
         SensorConfiguration m_sensorConfiguration;
-        AZStd::unique_ptr<ROS2SensorBase> m_ros2Sensor;
         AZStd::unique_ptr<ROS2StaticTransformPublisher> m_staticTransformPublisher;
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -8,18 +8,10 @@
 
 #pragma once
 
-#include "SensorConfiguration.h"
-//#include <AzCore/Memory/SystemAllocator.h>
+#include "Sensor/SensorConfiguration.h"
 
 namespace ROS2
 {
-    namespace Internal
-    {
-
-    }
-
-    //AZ_CLASS_ALLOCATOR_IMPL(ROS2::SensorConfiguration, AZ::SystemAllocator, 0);
-
     void SensorConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -32,16 +24,6 @@ namespace ROS2
                 ->Field("Visualise", &SensorConfiguration::m_visualise)
                 ;
         }
-    }
-
-    AZStd::string SensorConfiguration::GetFrameID() const
-    {
-        return Internal::GetNamespacedName(m_namespace, m_frameName);
-    }
-
-    AZStd::string SensorConfiguration::GetTopic() const
-    {
-        return Internal::GetNamespacedName(m_namespace, m_topic);
     }
 }  // namespace ROS2
 

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -15,15 +15,7 @@ namespace ROS2
 {
     namespace Internal
     {
-        AZStd::string GetNamespacedName(const AZStd::string& ns, const AZStd::string& name)
-        {
-            AZStd::string namespacedName;
-            if (!ns.empty())
-            {
-                namespacedName = ns + "/";
-            }
-            namespacedName += name;
-        }
+
     }
 
     //AZ_CLASS_ALLOCATOR_IMPL(ROS2::SensorConfiguration, AZ::SystemAllocator, 0);
@@ -34,14 +26,10 @@ namespace ROS2
         {
             serializeContext->Class<SensorConfiguration>()
                 ->Version(1)
-                ->Field("Namespace", &SensorConfiguration::m_namespace)
-                ->Field("Frame Name", &SensorConfiguration::m_frameName)
                 ->Field("Topic", &SensorConfiguration::m_topic)
                 ->Field("Publishing Data", &SensorConfiguration::m_publishData)
                 ->Field("Frequency (HZ)", &SensorConfiguration::m_hz)
                 ->Field("Visualise", &SensorConfiguration::m_visualise)
-                ->Field("Publishing Transform", &RigidBodyConfiguration::m_publishTransform)
-                ->Field("Parent Frame Name", &SensorConfiguration::m_parentFrameName)
                 ;
         }
     }
@@ -51,7 +39,7 @@ namespace ROS2
         return Internal::GetNamespacedName(m_namespace, m_frameName);
     }
 
-    AZStd::string SensorConfiguration::GetPublishTopic() const
+    AZStd::string SensorConfiguration::GetTopic() const
     {
         return Internal::GetNamespacedName(m_namespace, m_topic);
     }

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.cpp
@@ -1,0 +1,59 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#pragma once
+
+#include "SensorConfiguration.h"
+//#include <AzCore/Memory/SystemAllocator.h>
+
+namespace ROS2
+{
+    namespace Internal
+    {
+        AZStd::string GetNamespacedName(const AZStd::string& ns, const AZStd::string& name)
+        {
+            AZStd::string namespacedName;
+            if (!ns.empty())
+            {
+                namespacedName = ns + "/";
+            }
+            namespacedName += name;
+        }
+    }
+
+    //AZ_CLASS_ALLOCATOR_IMPL(ROS2::SensorConfiguration, AZ::SystemAllocator, 0);
+
+    void SensorConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SensorConfiguration>()
+                ->Version(1)
+                ->Field("Namespace", &SensorConfiguration::m_namespace)
+                ->Field("Frame Name", &SensorConfiguration::m_frameName)
+                ->Field("Topic", &SensorConfiguration::m_topic)
+                ->Field("Publishing Data", &SensorConfiguration::m_publishData)
+                ->Field("Frequency (HZ)", &SensorConfiguration::m_hz)
+                ->Field("Visualise", &SensorConfiguration::m_visualise)
+                ->Field("Publishing Transform", &RigidBodyConfiguration::m_publishTransform)
+                ->Field("Parent Frame Name", &SensorConfiguration::m_parentFrameName)
+                ;
+        }
+    }
+
+    AZStd::string SensorConfiguration::GetFrameID() const
+    {
+        return Internal::GetNamespacedName(m_namespace, m_frameName);
+    }
+
+    AZStd::string SensorConfiguration::GetPublishTopic() const
+    {
+        return Internal::GetNamespacedName(m_namespace, m_topic);
+    }
+}  // namespace ROS2
+

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
@@ -6,7 +6,8 @@
 *
 */
 
-//#include <AzCore/Memory/Memory.h>
+#pragma once
+
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
@@ -16,8 +17,11 @@ namespace ROS2
     struct SensorConfiguration
     {
     public:
-        //AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
+
+        SensorConfiguration() = default;
+        virtual ~SensorConfiguration() = default;
+
         static void Reflect(AZ::ReflectContext* context);
 
         // TODO - publishing-related data
@@ -27,8 +31,6 @@ namespace ROS2
         // TODO - add QoS here (struct, mapped to ros2 QoS).
 
         bool m_visualise = true;
-
-        AZStd::string GetTopic() const;
     };
 }  // namespace ROS2
 

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+//#include <AzCore/Memory/Memory.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    /// General configuration for sensors
+    struct SensorConfiguration
+    {
+    public:
+        //AZ_CLASS_ALLOCATOR_DECL;
+        AZ_RTTI(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        // TODO - consider moving to ROS2Frame struct
+        AZStd::string m_namespace; // TODO - option to fill from entity name, default = true, validation
+        AZStd::string m_frameName = "sensor_frame"; // TODO - option to fill from entity name, validation
+
+        // TODO - publishing-related data
+        AZStd::string m_topic; // TODO - apply namespace, default to standard names per type, validation
+        bool m_publishData = true;
+        float m_hz = 10;
+        // TODO - add QoS here (struct, mapped to ros2 QoS).
+
+        bool m_visualise = true;
+
+        // TODO - transform-related data (ROS2Transform needs ROS2Frame, ROS2Publisher also needs ROS2Frame)
+        bool m_publishTransform = true;
+        AZStd::string m_parentFrameName = "base_link"; // TODO - option to fill from parent entity, default = false, validation
+
+        AZStd::string GetFrameID() const;
+        AZStd::string GetPublishTopic() const;
+    }
+}  // namespace ROS2
+

--- a/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
+++ b/Gems/ROS2/Code/Source/Sensor/SensorConfiguration.h
@@ -20,10 +20,6 @@ namespace ROS2
         AZ_RTTI(SensorConfiguration, "{4755363D-0B5A-42D7-BBEF-152D87BA10D7}");
         static void Reflect(AZ::ReflectContext* context);
 
-        // TODO - consider moving to ROS2Frame struct
-        AZStd::string m_namespace; // TODO - option to fill from entity name, default = true, validation
-        AZStd::string m_frameName = "sensor_frame"; // TODO - option to fill from entity name, validation
-
         // TODO - publishing-related data
         AZStd::string m_topic; // TODO - apply namespace, default to standard names per type, validation
         bool m_publishData = true;
@@ -32,12 +28,7 @@ namespace ROS2
 
         bool m_visualise = true;
 
-        // TODO - transform-related data (ROS2Transform needs ROS2Frame, ROS2Publisher also needs ROS2Frame)
-        bool m_publishTransform = true;
-        AZStd::string m_parentFrameName = "base_link"; // TODO - option to fill from parent entity, default = false, validation
-
-        AZStd::string GetFrameID() const;
-        AZStd::string GetPublishTopic() const;
-    }
+        AZStd::string GetTopic() const;
+    };
 }  // namespace ROS2
 

--- a/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.cpp
+++ b/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "ROS2/ROS2Bus.h"
+#include "Utilities/ROS2Names.h"
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ROS2
+{
+    namespace Internal
+    {
+        ROS2FrameComponent* GetParentROS2FrameComponent(const AZ::TransformInterface* transformInterface)
+        {
+            if (const AZ::TransformInterface* parentEntity = transformInterface->GetParent())
+            {
+                return parentEntity->FindComponent<ROS2FrameComponent>())
+            }
+            return nullptr;
+        }
+
+        const AZ::Transform& GetParentFrameTransform(const AZ::TransformInterface* transformInterface) const
+        {
+            if (Internal::GetParentROS2FrameComponent(transformInterface))
+            {   // it is used as "HasParentROS2FrameComponent(..)"
+                return transformInterface->GetLocalTM();
+            }
+            return transformInterface->GetWorldTM();
+        }
+    }
+
+    void ROS2FrameComponent::Activate()
+    {
+        m_transformInterface = GetEntity()->FindComponent<AzFramework::TransformComponent>();
+        m_frameTransform = GetParentFrameTransform(m_transformInterface);
+
+        m_staticTFPublisher = AZStd::make_unique<TransformPublisher>(GetParentFrameID(), GetFrameID(), m_frameTransform);
+    }
+
+    void ROS2FrameComponent::Deactivate()
+    {
+        m_staticTFPublisher.reset();
+    }
+
+    AZStd::string ROS2FrameComponent::GetParentFrameID()
+    {
+        AZStd::string parentID = "world";
+        if (auto parentFrame = Internal::GetParentROS2FrameComponent(GetTransformInterface()); parentFrame != nullptr)
+        {
+            return parentFrame->GetFrameID();
+        }
+    }
+
+    AZStd::string ROS2FrameComponent::GetFrameID()
+    {
+        return ROS2Names::GetNamespacedName(m_namespace, m_frameName);
+    }
+
+    void ROS2FrameComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serialize->Class<ROS2FrameComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("Namespace", &ROS2FrameComponent::m_namespace)
+                ->Field("Frame Name", &ROS2FrameComponent::m_frameName)
+                ;
+        }
+    }
+
+    void ROS2FrameComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC("TransformService"));
+    }
+} // namespace ROS2

--- a/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.h
@@ -22,23 +22,24 @@ namespace ROS2
     public:
         AZ_COMPONENT(ROS2SensorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
 
-        // AZ::Component interface implementation.
         void Activate() override;
         void Deactivate() override;
 
-        // Required Reflect function.
         static void Reflect(AZ::ReflectContext* context);
-
-        // TODO - exclude multiple ROS2Frames in entity on single level, expose interface
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+        static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
 
         // namespaced and validated, ready to send in ros2 messages (TODO-validate)
         AZStd::string GetFrameID() const;
+        AZStd::string GetNamespace() const;
+
+        // Transform for direct parent if parent ROS2Frame is found, otherwise transformation is global ("world")
+        const AZ::Transform& GetFrameTransform() const;
 
     private:
-        // Transform for direct parent if parent ROS2Frame is found, otherwise transformation is global ("world")
-        const AZ::Transform& m_frameTransform;
-        const AZ::TransformInterface* m_transformInterface;
+        const AZ::TransformInterface* GetEntityTransformInterface() const;
+        const ROS2FrameComponent* GetParentROS2FrameComponent() const;
 
         // If parent entity does not exist or does not have a ROS2Frame component, return ros2 default global frame: "world"
         AZStd::string GetParentFrameID() const;

--- a/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.h
+++ b/Gems/ROS2/Code/Source/Transform/ROS2FrameComponent.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include "TransformPublisher.h"
+#include <AzCore/Component/Component.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+namespace ROS2
+{
+    /// This component marks an interesting reference frame and captures common behavior
+    /// for sensor data frame of reference, publishing ros2 static and dynamic transforms (tf)
+    /// and helping to export robot prefab to URDF.
+    class ROS2FrameComponent
+        : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(ROS2SensorComponent, "{EE743472-3E25-41EA-961B-14096AC1D66F}", AZ::Component);
+
+        // AZ::Component interface implementation.
+        void Activate() override;
+        void Deactivate() override;
+
+        // Required Reflect function.
+        static void Reflect(AZ::ReflectContext* context);
+
+        // TODO - exclude multiple ROS2Frames in entity on single level, expose interface
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+
+        // namespaced and validated, ready to send in ros2 messages (TODO-validate)
+        AZStd::string GetFrameID() const;
+
+    private:
+        // Transform for direct parent if parent ROS2Frame is found, otherwise transformation is global ("world")
+        const AZ::Transform& m_frameTransform;
+        const AZ::TransformInterface* m_transformInterface;
+
+        // If parent entity does not exist or does not have a ROS2Frame component, return ros2 default global frame: "world"
+        AZStd::string GetParentFrameID() const;
+
+        // TODO - Editor component: validation of fields, constraints between values and so on
+        AZStd::string m_namespace; // TODO - option to fill from entity name, default = true, validation
+        AZStd::string m_frameName = "sensor_frame"; // TODO - option to fill from entity name, validation
+
+        // Whether relationship to parent frame is static (fixed joint) or dynamic
+        // TODO - this will be extended to URDF joint types
+        // bool m_isDynamic = true; // TODO - determine automatically
+
+        // TODO - transform-related data (ROS2Transform needs ROS2Frame, ROS2Publisher also needs ROS2Frame)
+        // bool m_publishTransform = true;
+        AZStd::unique_ptr<TransformPublisher> m_transformPublisher;
+    };
+}  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Transform/TransformPublisher.cpp
+++ b/Gems/ROS2/Code/Source/Transform/TransformPublisher.cpp
@@ -1,0 +1,30 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+
+#include "TransformPublisher.h"
+#include "ROS2/ROS2Bus.h"
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+namespace ROS2
+{
+    TransformPublisher::TransformPublisher(
+        const AZStd::string& parentFrame, const AZStd::string& childFrame, const AZ::Transform& o3deTransform)
+    {
+        auto ros2Node = ROS2Interface::Get()->GetNode();
+        m_staticTFPublisher = AZstd::make_unique<tf2_ros::StaticTransformBroadcaster>(ros2Node);
+
+        geometry_msgs::msg::TransformStamped t;
+
+        t.header.stamp = ROS2Interface::Get()->GetROSTimestamp();
+        t.header.frame_id = parentFrame;
+        t.child_frame_id = childFrame;
+        t.transform.translation = ROS2Conversions::ToROS2Vector(o3deTransform.GetTranslation());
+        t.transform.rotation = ROS2Conversions::ToROS2Quaternion(o3deTransform.GetRotation());
+        tf_publisher_->sendTransform(t);
+    }
+}  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Transform/TransformPublisher.h
+++ b/Gems/ROS2/Code/Source/Transform/TransformPublisher.h
@@ -7,7 +7,7 @@
 */
 #pragma once
 
-#include <AzCore/Maht/Transform.h>
+#include <AzCore/Math/Transform.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <tf2_ros/static_transform_broadcaster.h>

--- a/Gems/ROS2/Code/Source/Transform/TransformPublisher.h
+++ b/Gems/ROS2/Code/Source/Transform/TransformPublisher.h
@@ -1,0 +1,28 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: Apache-2.0 OR MIT
+*
+*/
+#pragma once
+
+#include <AzCore/Maht/Transform.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+namespace ROS2
+{
+   /// Publishes transforms as standard ros2 tf2 messages. Static transforms are published once.
+   // TODO - differentiate between static and dynamic publisher
+   class TransformPublisher
+   {
+   public:
+       TransformPublisher(const AZStd::string& parentFrame, const AZStd::string &childFrame,
+                          const AZ::Transform& transform);
+
+   private:
+       AZStd::unique_ptr<tf2_ros::StaticTransformBroadcaster> m_staticTFPublisher;
+   };
+}  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
@@ -23,7 +23,7 @@ namespace ROS2
         return ros2vector;
     }
 
-    static geometry_msgs::msg::Quaternion ROS2Conversions::ToROS2Quaternion(const AZ::Quaternion& azquaternion)
+    geometry_msgs::msg::Quaternion ROS2Conversions::ToROS2Quaternion(const AZ::Quaternion& azquaternion)
     {
         geometry_msgs::msg::Quaternion ros2Quaternion;
         ros2Quaternion.x = azquaternion.GetX();

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.cpp
@@ -22,4 +22,14 @@ namespace ROS2
         ros2vector.z = azvector.GetZ();
         return ros2vector;
     }
+
+    static geometry_msgs::msg::Quaternion ROS2Conversions::ToROS2Quaternion(const AZ::Quaternion& azquaternion)
+    {
+        geometry_msgs::msg::Quaternion ros2Quaternion;
+        ros2Quaternion.x = azquaternion.GetX();
+        ros2Quaternion.y = azquaternion.GetY();
+        ros2Quaternion.z = azquaternion.GetZ();
+        ros2Quaternion.w = azquaternion.GetW();
+        return ros2Quaternion;
+    }
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.h
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Conversions.h
@@ -18,5 +18,6 @@ namespace ROS2
     public:
         static AZ::Vector3 FromROS2Vector3(const geometry_msgs::msg::Vector3& ros2vector);
         static geometry_msgs::msg::Vector3 ToROS2Vector3(const AZ::Vector3& azvector);
+        static geometry_msgs::msg::Quaternion ToROS2Quaternion(const AZ::Quaternion& azquaternion);
     };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Names.cpp
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Names.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ROS2Names.h"
+
+namespace ROS2
+{
+    AZStd::string ROS2Names::GetNamespacedName(const AZStd::string& ns, const AZStd::string& name)
+    {
+        AZStd::string namespacedName;
+        if (!ns.empty())
+        {
+            namespacedName = ns + "/";
+        }
+        namespacedName += name;
+        return namespacedName;
+    }
+}  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Names.h
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Names.h
@@ -11,5 +11,9 @@
 
 namespace ROS2
 {
-    AZStd::string ROS2Names::GetNamespacedName(const AZStd::string& ns, const AZStd::string& name);
+    class ROS2Names
+    {
+    public:
+        static AZStd::string GetNamespacedName(const AZStd::string& ns, const AZStd::string& name);
+    };
 }  // namespace ROS2

--- a/Gems/ROS2/Code/Source/Utilities/ROS2Names.h
+++ b/Gems/ROS2/Code/Source/Utilities/ROS2Names.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/std/string/string.h>
+
+namespace ROS2
+{
+    AZStd::string ROS2Names::GetNamespacedName(const AZStd::string& ns, const AZStd::string& name);
+}  // namespace ROS2

--- a/Gems/ROS2/Code/ros2_files.cmake
+++ b/Gems/ROS2/Code/ros2_files.cmake
@@ -11,6 +11,10 @@ set(FILES
     Source/RobotControl/ROS2RobotControlComponent.h
     Source/RobotControl/TwistControl.cpp
     Source/RobotControl/TwistControl.h
+    Source/Sensor/ROS2SensorComponent.cpp
+    Source/Sensor/ROS2SensorComponent.h
+    Source/Sensor/SensorConfiguration.cpp
+    Source/Sensor/SensorConfiguration.h
     Source/ROS2ModuleInterface.h
     Source/ROS2SystemComponent.cpp
     Source/ROS2SystemComponent.h


### PR DESCRIPTION
Sensor abstraction for ros2 components:

1. Base component (ROS2SensorComponent)
2. Adjusted ROS2LidarSensorComponent
3. ROS2FrameComponent - ros2 frame is a distinct concept. It is used in published data (so, for sensors), as a reflection of URDF structure, and to publish static transforms (dynamic transforms are not handled yet). ROS2Frame is also a natural fit to handle namespace responsibility (both topics and frame_ids typically share the namespace).
4. TransformPublisher - publishes static transforms. 
5. Utilities folder has been added, with ROS2Names added: utility to create and validate (not yet - will use ros2 api for that) ros2 names such as topics and frame_ids.
6. Some general improvements in design