### PR TITLE
Revert "engine unique name"

### DIFF
--- a/engine.json
+++ b/engine.json
@@ -1,5 +1,5 @@
 {
-    "engine_name": "o3de_amr_sim",
+    "engine_name": "o3de",
     "restricted": "o3de",
     "O3DEVersion": "0.1.0.0",
     "O3DEBuildNumber": 0,


### PR DESCRIPTION
## What does this PR do?

This reverts commit 8672307663911cf1ee9d8d3b39e816f7904b1eb6. And reintroduces standard name for the engine. This fixes the issue with unresolved gem dependencies

## How was this PR tested?

Rebuilt engine locally
