### PR TITLE
Fix BRDF initialization in rhi-null use case

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -671,7 +671,8 @@ namespace AZ
                // As part of our initialization we need to create the BRDF texture generation pipeline
                AZ::RPI::RenderPipelineDescriptor pipelineDesc;
                pipelineDesc.m_mainViewTagName = "MainCamera";
-               pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportContext->GetId());
+               const AzFramework::ViewportId viewportId = viewportContext ? viewportContext->GetId() : AzFramework::InvalidViewportId;
+               pipelineDesc.m_name = AZStd::string::format("BRDFTexturePipeline_%i", viewportId);
                pipelineDesc.m_rootPassTemplate = "BRDFTexturePipeline";
                pipelineDesc.m_executeOnce = true;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes null pointer dereferencing that can be caused by running `-rhi=null` scenario.
It was experienced here : https://github.com/o3de/o3de/pull/18649#issuecomment-2627877696.

This PR does not require fix in development, since code in `BootstrapSystemComponent.cpp` is heavily modified in dev comparing to 2409.1 

## How was this PR tested?

Run game launcher with and test against issue https://github.com/o3de/o3de-extras/issues/792.
- `-rhi=null -console-mode` - starts without assertions and crashes (produce some warnings regarding ROS 2 Gem)
- `-rhi=vulkan -console-mode`- works, does not reintroduce [issue](https://github.com/o3de/o3de-extras/issues/792.) 

