### PR TITLE
Decouple AssImp from Scene Importer

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpNodeWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpNodeWrapper.h
@@ -11,6 +11,8 @@
 
 struct aiScene;
 
+struct aiNode;
+
 namespace AZ
 {
     namespace AssImpSDKWrapper

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <AssImpTypeConverter.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
 #include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <assimp/postprocess.h>
 
@@ -39,11 +39,12 @@ namespace AZ
         }
 
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
-        void signal_handler([[maybe_unused]] int signal) 
+        void signal_handler([[maybe_unused]] int signal)
         {
             AZ_TracePrintf(
                 SceneAPI::Utilities::ErrorWindow,
-                "Failed to import scene with Asset Importer library. An %s has occurred in the library, this scene file cannot be parsed by the library.",
+                "Failed to import scene with Asset Importer library. An %s has occurred in the library, this scene file cannot be parsed "
+                "by the library.",
                 signal == SIGABRT ? "assert" : "unknown error");
         }
 #endif // AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
@@ -59,7 +60,7 @@ namespace AZ
 #ifdef _WRITE_ABORT_MSG
             _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif // #ifdef _WRITE_ABORT_MSG
-            // Instead, capture any calls to abort with a signal handler, and report them.
+       // Instead, capture any calls to abort with a signal handler, and report them.
             auto previous_handler = std::signal(SIGABRT, signal_handler);
 #endif // AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
 
@@ -72,12 +73,11 @@ namespace AZ
             // aiProcess_JoinIdenticalVertices is not enabled because O3DE has a mesh optimizer that also does this,
             // this flag is disabled to keep AssImp output similar to FBX SDK to reduce downstream bugs for the initial AssImp release.
             // There's currently a minimum of properties and flags set to maximize compatibility with the existing node graph.
-            unsigned int importFlags =
-                aiProcess_Triangulate                                               // Triangulates all faces of all meshes
-                | static_cast<unsigned long>(aiProcess_GenBoundingBoxes)            // Generate bounding boxes
-                | aiProcess_GenNormals                                              // Generate normals for meshes
-                | (importSettings.m_optimizeScene ? aiProcess_OptimizeGraph : 0)    // Merge excess scene nodes together
-                | (importSettings.m_optimizeMeshes ? aiProcess_OptimizeMeshes : 0)  // Combines meshes in the scene together
+            unsigned int importFlags = aiProcess_Triangulate // Triangulates all faces of all meshes
+                | static_cast<unsigned long>(aiProcess_GenBoundingBoxes) // Generate bounding boxes
+                | aiProcess_GenNormals // Generate normals for meshes
+                | (importSettings.m_optimizeScene ? aiProcess_OptimizeGraph : 0) // Merge excess scene nodes together
+                | (importSettings.m_optimizeMeshes ? aiProcess_OptimizeMeshes : 0) // Combines meshes in the scene together
                 ;
 
             // aiProcess_LimitBoneWeights is not enabled because it will remove bones which are not associated with a mesh.
@@ -101,7 +101,10 @@ namespace AZ
 
             if (!m_assImpScene)
             {
-                AZ_TracePrintf(SceneAPI::Utilities::ErrorWindow, "Failed to import Asset Importer Scene. Error returned: %s", m_importer->GetErrorString());
+                AZ_TracePrintf(
+                    SceneAPI::Utilities::ErrorWindow,
+                    "Failed to import Asset Importer Scene. Error returned: %s",
+                    m_importer->GetErrorString());
                 return false;
             }
 

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -8,10 +8,10 @@
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <assimp/postprocess.h>
 
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
@@ -43,8 +43,7 @@ namespace AZ
         {
             AZ_TracePrintf(
                 SceneAPI::Utilities::ErrorWindow,
-                "Failed to import scene with Asset Importer library. An %s has occurred in the library, this scene file cannot be parsed "
-                "by the library.",
+                "Failed to import scene with Asset Importer library. An %s has occurred in the library, this scene file cannot be parsed by the library.",
                 signal == SIGABRT ? "assert" : "unknown error");
         }
 #endif // AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
@@ -60,7 +59,7 @@ namespace AZ
 #ifdef _WRITE_ABORT_MSG
             _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif // #ifdef _WRITE_ABORT_MSG
-       // Instead, capture any calls to abort with a signal handler, and report them.
+            // Instead, capture any calls to abort with a signal handler, and report them.
             auto previous_handler = std::signal(SIGABRT, signal_handler);
 #endif // AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
 
@@ -73,11 +72,12 @@ namespace AZ
             // aiProcess_JoinIdenticalVertices is not enabled because O3DE has a mesh optimizer that also does this,
             // this flag is disabled to keep AssImp output similar to FBX SDK to reduce downstream bugs for the initial AssImp release.
             // There's currently a minimum of properties and flags set to maximize compatibility with the existing node graph.
-            unsigned int importFlags = aiProcess_Triangulate // Triangulates all faces of all meshes
-                | static_cast<unsigned long>(aiProcess_GenBoundingBoxes) // Generate bounding boxes
-                | aiProcess_GenNormals // Generate normals for meshes
-                | (importSettings.m_optimizeScene ? aiProcess_OptimizeGraph : 0) // Merge excess scene nodes together
-                | (importSettings.m_optimizeMeshes ? aiProcess_OptimizeMeshes : 0) // Combines meshes in the scene together
+            unsigned int importFlags =
+                aiProcess_Triangulate                                               // Triangulates all faces of all meshes
+                | static_cast<unsigned long>(aiProcess_GenBoundingBoxes)            // Generate bounding boxes
+                | aiProcess_GenNormals                                              // Generate normals for meshes
+                | (importSettings.m_optimizeScene ? aiProcess_OptimizeGraph : 0)    // Merge excess scene nodes together
+                | (importSettings.m_optimizeMeshes ? aiProcess_OptimizeMeshes : 0)  // Combines meshes in the scene together
                 ;
 
             // aiProcess_LimitBoneWeights is not enabled because it will remove bones which are not associated with a mesh.
@@ -101,10 +101,7 @@ namespace AZ
 
             if (!m_assImpScene)
             {
-                AZ_TracePrintf(
-                    SceneAPI::Utilities::ErrorWindow,
-                    "Failed to import Asset Importer Scene. Error returned: %s",
-                    m_importer->GetErrorString());
+                AZ_TracePrintf(SceneAPI::Utilities::ErrorWindow, "Failed to import Asset Importer Scene. Error returned: %s", m_importer->GetErrorString());
                 return false;
             }
 
@@ -157,7 +154,7 @@ namespace AZ
 
         void AssImpSceneWrapper::Clear()
         {
-            if (m_importer)
+            if(m_importer)
             {
                 m_importer->FreeScene();
                 m_importer = AZStd::make_unique<Assimp::Importer>();

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.cpp
@@ -5,12 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <AssImpTypeConverter.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SceneCore/Utilities/Reporting.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <assimp/postprocess.h>
 
 #if AZ_TRAIT_COMPILER_SUPPORT_CSIGNAL
@@ -153,7 +154,7 @@ namespace AZ
 
         void AssImpSceneWrapper::Clear()
         {
-            if(m_importer)
+            if (m_importer)
             {
                 m_importer->FreeScene();
                 m_importer = AZStd::make_unique<Assimp::Importer>();
@@ -184,6 +185,37 @@ namespace AZ
             result.first = static_cast<AssImpSceneWrapper::AxisVector>(frontVectorRead);
             return result;
         }
-    }//namespace AssImpSDKWrapper
+
+        float AssImpSceneWrapper::GetUnitSizeInMeters() const
+        {
+            float unitSizeInMeters;
+            float originalUnitSizeInMeters;
+            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor".
+             * This particular metadata is FBX format only. */
+            if (m_assImpScene->mMetaData->HasKey("UnitScaleFactor") || m_assImpScene->mMetaData->HasKey("OriginalUnitScaleFactor"))
+            {
+                // If either metadata piece is not available, the default of 1 will be used.
+                m_assImpScene->mMetaData->Get("UnitScaleFactor", unitSizeInMeters);
+                m_assImpScene->mMetaData->Get("OriginalUnitScaleFactor", originalUnitSizeInMeters);
+
+                /* Conversion factor for converting from centimeters to meters.
+                 * This applies to an FBX format in which the default unit is a centimeter. */
+                unitSizeInMeters = unitSizeInMeters * .01f;
+            }
+            else
+            {
+                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
+                auto rootTransform = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(m_assImpScene->mRootNode->mTransformation);
+                unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
+            }
+            return unitSizeInMeters;
+        }
+
+        AZ::Aabb AssImpSceneWrapper::GetAABB() const
+        {
+            return AZ::Aabb::CreateFromMinMaxValues(
+                m_aabb.mMin.x, m_aabb.mMin.y, m_aabb.mMin.z, m_aabb.mMax.x, m_aabb.mMax.y, m_aabb.mMax.z);
+        }
+    } // namespace AssImpSDKWrapper
 
 } // namespace AZ

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -34,20 +34,13 @@ namespace AZ
             void Clear() override;
             void CalculateAABBandVertices(const aiScene* scene, aiAABB& aabb, uint32_t& vertices);
 
-            enum class AxisVector
-            {
-                X = 0,
-                Y = 1,
-                Z = 2,
-                Unknown
-            };
-
-            AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const;
-            AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
+            AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const override;
+            AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const override;
+            float GetUnitSizeInMeters() const override;
 
             AZStd::string GetSceneFileName() const { return m_sceneFileName; }
-            aiAABB GetAABB() const { return m_aabb; }
-            uint32_t GetVertices() const { return m_vertices; }
+            AZ::Aabb GetAABB() const override;
+            uint32_t GetVerticesCount() const override { return m_vertices; }
         protected:
             const aiScene* m_assImpScene = nullptr;
             AZStd::unique_ptr<Assimp::Importer> m_importer;

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.cpp
@@ -34,20 +34,6 @@ namespace AZ
             return transform;
         }
 
-        SceneAPI::DataTypes::MatrixType AssImpTypeConverter::ToTransform(const AZ::Matrix4x4& matrix)
-        {
-            SceneAPI::DataTypes::MatrixType transform;
-            for (int row = 0; row < 3; ++row)
-            {
-                for (int column = 0; column < 4; ++column)
-                {
-                    transform.SetElement(row, column, matrix.GetElement(row, column));
-                }
-            }
-
-            return transform;
-        }
-
         SceneAPI::DataTypes::Color AssImpTypeConverter::ToColor(const aiColor4D& color)
         {
             return AZ::SceneAPI::DataTypes::Color(color.r, color.g, color.b, color.a);

--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpTypeConverter.h
@@ -27,7 +27,6 @@ namespace AZ
         {
         public:
             static SceneAPI::DataTypes::MatrixType ToTransform(const aiMatrix4x4& matrix);
-            static SceneAPI::DataTypes::MatrixType ToTransform(const AZ::Matrix4x4& matrix);
             static SceneAPI::DataTypes::Color ToColor(const aiColor4D& color);
             static AZ::Vector3 ToVector3(const aiVector3D& vector3);
         };

--- a/Code/Tools/SceneAPI/SDKWrapper/MaterialWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/MaterialWrapper.h
@@ -11,8 +11,6 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/Math/Vector3.h>
 
-struct aiMaterial;
-
 namespace AZ
 {
     namespace SDKMaterial

--- a/Code/Tools/SceneAPI/SDKWrapper/NodeWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/NodeWrapper.h
@@ -9,8 +9,6 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 
-struct aiNode;
-
 namespace AZ
 {
     namespace SDKNode

--- a/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.cpp
+++ b/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#include <AzCore/Math/Aabb.h>
 #include <SceneAPI/SDKWrapper/SceneWrapper.h>
 
 namespace AZ
@@ -36,5 +37,47 @@ namespace AZ
         void SceneWrapperBase::Clear()
         {
         }
+
+        AZStd::pair<SceneWrapperBase::AxisVector, int32_t> SceneWrapperBase::GetUpVectorAndSign() const
+        {
+            return {AxisVector::Z, 1};
+        }
+
+        AZStd::pair<SceneWrapperBase::AxisVector, int32_t> SceneWrapperBase::GetFrontVectorAndSign() const
+        {
+            return { AxisVector::X, 1};
+        }
+
+        float SceneWrapperBase::GetUnitSizeInMeters() const
+        {
+            return 1.0f;
+        }
+
+        AZ::Aabb SceneWrapperBase::GetAABB() const
+        {
+            return AZ::Aabb::CreateNull();
+        }
+
+        uint32_t SceneWrapperBase::GetVerticesCount() const
+        {
+            return 0u;
+        }
+
+
+        SceneAPI::DataTypes::MatrixType SceneTypeConverter::ToTransform(const AZ::Matrix4x4& matrix)
+        {
+            SceneAPI::DataTypes::MatrixType transform;
+            for (int row = 0; row < 3; ++row)
+            {
+                for (int column = 0; column < 4; ++column)
+                {
+                    transform.SetElement(row, column, matrix.GetElement(row, column));
+                }
+            }
+
+            return transform;
+        }
+
+
     } //namespace SDKScene
 }// namespace AZ

--- a/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/SceneWrapper.h
@@ -8,10 +8,10 @@
 #pragma once
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/Math/Aabb.h>
 #include <SceneAPI/SDKWrapper/NodeWrapper.h>
+#include <SceneAPI/SceneCore/DataTypes/MatrixType.h>
 #include <SceneAPI/SceneCore/Import/SceneImportSettings.h>
-
-struct aiScene;
 
 namespace AZ
 {
@@ -31,8 +31,28 @@ namespace AZ
 
             virtual void Clear();
 
+            enum class AxisVector
+            {
+                X = 0,
+                Y = 1,
+                Z = 2,
+                Unknown
+            };
+
+            virtual AZStd::pair<AxisVector, int32_t> GetUpVectorAndSign() const;
+            virtual AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
+            virtual float GetUnitSizeInMeters() const;
+            virtual AZ::Aabb GetAABB() const;
+            virtual uint32_t GetVerticesCount() const;
+
             static const char* s_defaultSceneName;
         };
 
-    } //namespace Scene
-} //namespace AZ
+        class SceneTypeConverter
+        {
+        public:
+            static SceneAPI::DataTypes::MatrixType ToTransform(const AZ::Matrix4x4& matrix);
+        };
+
+    } // namespace SDKScene
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
@@ -8,30 +8,29 @@
 
 #if !defined(AZ_MONOLITHIC_BUILD)
 
-#include "ImportContexts/AssImpImportContextProvider.h"
-#include "SceneBuilderSystemComponent.h"
-
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
-#include <AzCore/Module/Environment.h>
 #include <AzCore/std/containers/vector.h>
-#include <SceneAPI/SceneBuilder/ImportContextRegistry.h>
+#include <AzCore/Module/Environment.h>
 #include <SceneAPI/SceneBuilder/SceneImportRequestHandler.h>
 
-#include <SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.h>
+#include <SceneAPI/SceneBuilder/SceneImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpMeshImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpSkinImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.h>
-#include <SceneAPI/SceneBuilder/SceneImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpSkinImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h>
+#include <SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h>
+
 
 namespace AZ
 {

--- a/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/DllMain.cpp
@@ -8,26 +8,30 @@
 
 #if !defined(AZ_MONOLITHIC_BUILD)
 
+#include "ImportContexts/AssImpImportContextProvider.h"
+#include "SceneBuilderSystemComponent.h"
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
-#include <AzCore/std/containers/vector.h>
 #include <AzCore/Module/Environment.h>
+#include <AzCore/std/containers/vector.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistry.h>
 #include <SceneAPI/SceneBuilder/SceneImportRequestHandler.h>
 
-#include <SceneAPI/SceneBuilder/SceneImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpMeshImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpSkinImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpSkinImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpAnimationImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.h>
+#include <SceneAPI/SceneBuilder/SceneImporter.h>
 
 namespace AZ
 {
@@ -49,6 +53,9 @@ namespace AZ
                     // Global importer and behavior
                     g_componentDescriptors.push_back(SceneBuilder::SceneImporter::CreateDescriptor());
                     g_componentDescriptors.push_back(SceneImportRequestHandler::CreateDescriptor());
+
+                    // ImportContextProviderRegistry
+                    g_componentDescriptors.push_back(SceneBuilderSystemComponent::CreateDescriptor());
 
                     // Node and attribute importers
                     g_componentDescriptors.push_back(AssImpBitangentStreamImporter::CreateDescriptor());
@@ -103,6 +110,8 @@ namespace AZ
 
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule()
 {
+    // Scott-Meyers singleton as no clear way how to add SystemComponent to module
+    AZ::SceneAPI::SceneBuilder::ImportContextRegistryManager::GetInstance();
 }
 extern "C" AZ_DLL_EXPORT void Reflect(AZ::SerializeContext* context)
 {

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistry.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistry.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            struct ImportContextProvider;
+
+            // ImportContextRegistry realizes Abstract Factory Pattern.
+            // It provides a family of objects related to a particular Import Context.
+            // Those include ImportContext specializations for different stages of the Import pipeline
+            // as well as Scene and Node wrappers.
+            // To add a new library for importing scene assets:
+            // - specialize and implement the ImportContextProvider
+            // - register specialization with this interface
+            class ImportContextRegistry
+            {
+            public:
+                AZ_RTTI(ImportContextRegistry, "{5faaaa8a-2497-41d7-8b5c-5af4390af776}");
+                AZ_CLASS_ALLOCATOR(ImportContextRegistry, AZ::SystemAllocator, 0);
+
+                virtual ~ImportContextRegistry() = default;
+
+                virtual void RegisterContextProvider(ImportContextProvider* provider) = 0;
+                virtual void UnregisterContextProvider(ImportContextProvider* provider) = 0;
+                virtual ImportContextProvider* SelectImportProvider(AZStd::string_view fileExtension) const = 0;
+            };
+
+            using ImportContextRegistryInterface = AZ::Interface<ImportContextRegistry>;
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ImportContextRegistryManager.h"
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            ImportContextRegistryManager::ImportContextRegistryManager()
+            {
+                // register AssImp default provider
+                auto assimpContextProvider = aznew AssImpImportContextProvider();
+                m_importContextProviders.push_back(AZStd::unique_ptr<ImportContextProvider>(assimpContextProvider));
+            };
+
+            void ImportContextRegistryManager::RegisterContextProvider(ImportContextProvider* provider)
+            {
+                if (provider)
+                {
+                    m_importContextProviders.push_back(AZStd::unique_ptr<ImportContextProvider>(provider));
+                }
+            }
+
+            void ImportContextRegistryManager::UnregisterContextProvider(ImportContextProvider* provider)
+            {
+                AZ_TracePrintf("SceneAPI", "Unregistered ImportContextProvider %s", provider->GetImporterName().data());
+                for (auto it = m_importContextProviders.begin(); it != m_importContextProviders.end(); ++it)
+                {
+                    if (it->get() == provider)
+                    {
+                        m_importContextProviders.erase(it);
+                        break; // Assuming only one instance can be registered at a time
+                    }
+                }
+            }
+
+            ImportContextProvider* ImportContextRegistryManager::SelectImportProvider(AZStd::string_view fileExtension) const
+            {
+                AZ_TracePrintf(
+                    "SceneAPI",
+                    "Finding ImportContextProvider (registered %d) suitable for extension: %.*s",
+                    m_importContextProviders.size(),
+                    static_cast<int>(fileExtension.length()),
+                    fileExtension.data());
+                // search in reverse order since the default AssImp Provider can handle all extenstions
+                for (auto it = m_importContextProviders.rbegin(); it != m_importContextProviders.rend(); ++it)
+                {
+                    if (it->get()->CanHandleExtension(fileExtension))
+                    {
+                        return it->get();
+                    }
+                    else
+                    {
+                        AZ_TracePrintf(
+                            "SceneAPI",
+                            "Importer %s cannot handle %.*s",
+                            it->get()->GetImporterName().data(),
+                            static_cast<int>(fileExtension.length()),
+                            fileExtension.data());
+                    }
+                }
+                return nullptr; // No provider found
+            }
+            ImportContextRegistryManager& ImportContextRegistryManager::GetInstance()
+            {
+                static ImportContextRegistryManager instance;
+                return instance;
+            }
+
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContextRegistryManager.h
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+#include <SceneAPI/SceneBuilder/ImportContextRegistry.h>
+#include <AzCore/Debug/Trace.h>
+#include <AzCore/std/containers/vector.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Implementation of the ImportContextRegistryInterface.
+            class ImportContextRegistryManager : public ImportContextRegistryInterface::Registrar
+            {
+            public:
+                AZ_RTTI(ImportContextRegistryManager, "{d3107473-4f99-4421-b4a8-ece66a922191}", ImportContextRegistry);
+                AZ_CLASS_ALLOCATOR(ImportContextRegistryManager, AZ::SystemAllocator, 0);
+
+                ImportContextRegistryManager();
+                ImportContextRegistryManager(const ImportContextRegistryManager&) = delete;
+                ImportContextRegistryManager& operator=(const ImportContextRegistryManager&) = delete;
+
+                ~ImportContextRegistryManager() override = default;
+
+                void RegisterContextProvider(ImportContextProvider* provider) override;
+                void UnregisterContextProvider(ImportContextProvider* provider) override;
+                ImportContextProvider* SelectImportProvider(AZStd::string_view fileExtension) const override;
+
+                static ImportContextRegistryManager& GetInstance();
+            private:
+                AZStd::vector<AZStd::unique_ptr<ImportContextProvider>> m_importContextProviders;
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
@@ -15,7 +15,7 @@ namespace AZ
     {
         namespace SceneBuilder
         {
-            AZStd::shared_ptr<NodeEncounteredContextBase> AssImpImportContextProvider::CreateNodeEncounteredContext(
+            AZStd::shared_ptr<NodeEncounteredContext> AssImpImportContextProvider::CreateNodeEncounteredContext(
                 Containers::Scene& scene,
                 Containers::SceneGraph::NodeIndex currentGraphPosition,
                 const SceneSystem& sourceSceneSystem,
@@ -45,7 +45,7 @@ namespace AZ
             }
 
             AZStd::shared_ptr<SceneDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneDataPopulatedContext(
-                NodeEncounteredContextBase& parent, AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
+                NodeEncounteredContext& parent, AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
             {
                 // Downcast the parent to the AssImp-specific type to access AssImpImportContext members
                 AssImpNodeEncounteredContext* assImpParent = azrtti_cast<AssImpNodeEncounteredContext*>(&parent);

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "AssImpImportContextProvider.h"
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            AZStd::shared_ptr<NodeEncounteredContextBase> AssImpImportContextProvider::CreateNodeEncounteredContext(
+                Containers::Scene& scene,
+                Containers::SceneGraph::NodeIndex currentGraphPosition,
+                const SceneSystem& sourceSceneSystem,
+                RenamedNodesMap& nodeNameMap,
+                SDKScene::SceneWrapperBase& sourceScene,
+                SDKNode::NodeWrapper& sourceNode)
+            {
+                // need to cast NodeWrapper
+                auto assImpNode = azrtti_cast<AZ::AssImpSDKWrapper::AssImpNodeWrapper*>(&sourceNode);
+                auto assImpScene = azrtti_cast<AZ::AssImpSDKWrapper::AssImpSceneWrapper*>(&sourceScene);
+
+                if (!assImpNode)
+                {
+                    // Handle error: parent is not of the expected type
+                    AZ_Error("SceneBuilder", false, "Incorrect node type. Cannot create NodeEncounteredContext");
+                    return nullptr;
+                }
+                if (!assImpScene)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create NodeEncounteredContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpNodeEncounteredContext>(
+                    scene, currentGraphPosition, *assImpScene, sourceSceneSystem, nodeNameMap, *assImpNode);
+            }
+
+            AZStd::shared_ptr<SceneDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneDataPopulatedContext(
+                NodeEncounteredContextBase& parent, AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
+            {
+                // Downcast the parent to the AssImp-specific type to access AssImpImportContext members
+                AssImpNodeEncounteredContext* assImpParent = azrtti_cast<AssImpNodeEncounteredContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneDataPopulatedContext");
+                    return nullptr;
+                }
+
+                return AZStd::make_shared<AssImpSceneDataPopulatedContext>(*assImpParent, AZStd::move(graphData), dataName);
+            }
+
+            AZStd::shared_ptr<SceneNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneNodeAppendedContext(
+                SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneDataPopulatedContext* assImpParent = azrtti_cast<AssImpSceneDataPopulatedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeAppendedContext");
+                    return nullptr;
+                }
+
+                return AZStd::make_shared<AssImpSceneNodeAppendedContext>(*assImpParent, newIndex);
+            }
+
+            AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneAttributeDataPopulatedContext(
+                SceneNodeAppendedContextBase& parent,
+                AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                const AZStd::string& dataName)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAppendedContext* assImpParent = azrtti_cast<AssImpSceneNodeAppendedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeDataPopulatedContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpSceneAttributeDataPopulatedContext>(
+                    *assImpParent, AZStd::move(nodeData), attributeNodeIndex, dataName);
+            }
+
+            AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneAttributeNodeAppendedContext(
+                SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneAttributeDataPopulatedContext* assImpParent = azrtti_cast<AssImpSceneAttributeDataPopulatedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeNodeAppendedContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpSceneAttributeNodeAppendedContext>(*assImpParent, newIndex);
+            }
+
+            AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> AssImpImportContextProvider::CreateSceneNodeAddedAttributesContext(
+                SceneNodeAppendedContextBase& parent)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAppendedContext* assImpParent = azrtti_cast<AssImpSceneNodeAppendedContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeAddedAttributesContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpSceneNodeAddedAttributesContext>(*assImpParent);
+            }
+
+            AZStd::shared_ptr<SceneNodeFinalizeContextBase> AssImpImportContextProvider::CreateSceneNodeFinalizeContext(
+                SceneNodeAddedAttributesContextBase& parent)
+            {
+                // Downcast the parent to the AssImp-specific type
+                AssImpSceneNodeAddedAttributesContext* assImpParent = azrtti_cast<AssImpSceneNodeAddedAttributesContext*>(&parent);
+                if (!assImpParent)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeFinalizeContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpSceneNodeFinalizeContext>(*assImpParent);
+            }
+
+            AZStd::shared_ptr<FinalizeSceneContextBase> AssImpImportContextProvider::CreateFinalizeSceneContext(
+                Containers::Scene& scene,
+                const SceneSystem& sourceSceneSystem,
+                SDKScene::SceneWrapperBase& sourceScene,
+                RenamedNodesMap& nodeNameMap)
+            {
+                AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<AssImpSDKWrapper::AssImpSceneWrapper*>(&sourceScene);
+                if (!assImpScene)
+                {
+                    AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create FinalizeSceneContext");
+                    return nullptr;
+                }
+                return AZStd::make_shared<AssImpFinalizeSceneContext>(scene, *assImpScene, sourceSceneSystem, nodeNameMap);
+            }
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.cpp
@@ -38,8 +38,10 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create NodeEncounteredContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpNodeEncounteredContext>(
+                auto context = AZStd::make_shared<AssImpNodeEncounteredContext>(
                     scene, currentGraphPosition, *assImpScene, sourceSceneSystem, nodeNameMap, *assImpNode);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneDataPopulatedContext(
@@ -53,7 +55,10 @@ namespace AZ
                     return nullptr;
                 }
 
-                return AZStd::make_shared<AssImpSceneDataPopulatedContext>(*assImpParent, AZStd::move(graphData), dataName);
+                auto context = AZStd::make_shared<AssImpSceneDataPopulatedContext>(*assImpParent, AZStd::move(graphData), dataName);
+
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneNodeAppendedContext(
@@ -67,7 +72,9 @@ namespace AZ
                     return nullptr;
                 }
 
-                return AZStd::make_shared<AssImpSceneNodeAppendedContext>(*assImpParent, newIndex);
+                auto context = AZStd::make_shared<AssImpSceneNodeAppendedContext>(*assImpParent, newIndex);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> AssImpImportContextProvider::CreateSceneAttributeDataPopulatedContext(
@@ -83,8 +90,10 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeDataPopulatedContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpSceneAttributeDataPopulatedContext>(
+                auto context = AZStd::make_shared<AssImpSceneAttributeDataPopulatedContext>(
                     *assImpParent, AZStd::move(nodeData), attributeNodeIndex, dataName);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> AssImpImportContextProvider::CreateSceneAttributeNodeAppendedContext(
@@ -97,7 +106,9 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneAttributeNodeAppendedContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpSceneAttributeNodeAppendedContext>(*assImpParent, newIndex);
+                auto context = AZStd::make_shared<AssImpSceneAttributeNodeAppendedContext>(*assImpParent, newIndex);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> AssImpImportContextProvider::CreateSceneNodeAddedAttributesContext(
@@ -110,7 +121,9 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeAddedAttributesContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpSceneNodeAddedAttributesContext>(*assImpParent);
+                auto context = AZStd::make_shared<AssImpSceneNodeAddedAttributesContext>(*assImpParent);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<SceneNodeFinalizeContextBase> AssImpImportContextProvider::CreateSceneNodeFinalizeContext(
@@ -123,7 +136,9 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect type of parent. Cannot create SceneNodeFinalizeContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpSceneNodeFinalizeContext>(*assImpParent);
+                auto context = AZStd::make_shared<AssImpSceneNodeFinalizeContext>(*assImpParent);
+                context->m_contextProvider = this;
+                return context;
             }
 
             AZStd::shared_ptr<FinalizeSceneContextBase> AssImpImportContextProvider::CreateFinalizeSceneContext(
@@ -138,7 +153,9 @@ namespace AZ
                     AZ_Error("SceneBuilder", false, "Incorrect scene type. Cannot create FinalizeSceneContext");
                     return nullptr;
                 }
-                return AZStd::make_shared<AssImpFinalizeSceneContext>(scene, *assImpScene, sourceSceneSystem, nodeNameMap);
+                auto context = AZStd::make_shared<AssImpFinalizeSceneContext>(scene, *assImpScene, sourceSceneSystem, nodeNameMap);
+                context->m_contextProvider = this;
+                return context;
             }
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
@@ -28,7 +28,7 @@ namespace AZ
 
                 AssImpImportContextProvider() = default;
 
-                AZStd::shared_ptr<NodeEncounteredContextBase> CreateNodeEncounteredContext(
+                AZStd::shared_ptr<NodeEncounteredContext> CreateNodeEncounteredContext(
                     Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     const SceneSystem& sourceSceneSystem,
@@ -37,7 +37,7 @@ namespace AZ
                     SDKNode::NodeWrapper& sourceNode) override;
 
                 AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
-                    NodeEncounteredContextBase& parent,
+                    NodeEncounteredContext& parent,
                     AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
                     const AZStd::string& dataName) override;
 

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ImportContextProvider.h"
+
+#include <AzCore/RTTI/RTTIMacros.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Concrete provider for creating AssImp-specific import classes.
+            struct AssImpImportContextProvider : public ImportContextProvider
+            {
+                AZ_RTTI(AssImpImportContextProvider, "{6c263adb-e73c-4017-955a-9c212ded3637}");
+
+                AssImpImportContextProvider() = default;
+
+                AZStd::shared_ptr<NodeEncounteredContextBase> CreateNodeEncounteredContext(
+                    Containers::Scene& scene,
+                    Containers::SceneGraph::NodeIndex currentGraphPosition,
+                    const SceneSystem& sourceSceneSystem,
+                    RenamedNodesMap& nodeNameMap,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    SDKNode::NodeWrapper& sourceNode) override;
+
+                AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
+                    NodeEncounteredContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
+                    const AZStd::string& dataName) override;
+
+                AZStd::shared_ptr<SceneNodeAppendedContextBase> CreateSceneNodeAppendedContext(
+                    SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) override;
+
+                AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> CreateSceneAttributeDataPopulatedContext(
+                    SceneNodeAppendedContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                    const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                    const AZStd::string& dataName) override;
+
+                AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> CreateSceneAttributeNodeAppendedContext(
+                    SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) override;
+
+                AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> CreateSceneNodeAddedAttributesContext(
+                    SceneNodeAppendedContextBase& parent) override;
+
+                AZStd::shared_ptr<SceneNodeFinalizeContextBase> CreateSceneNodeFinalizeContext(
+                    SceneNodeAddedAttributesContextBase& parent) override;
+
+                AZStd::shared_ptr<FinalizeSceneContextBase> CreateFinalizeSceneContext(
+                    Containers::Scene& scene, const SceneSystem& sourceSceneSystem, SDKScene::SceneWrapperBase& sourceScene, RenamedNodesMap& nodeNameMap) override;
+
+                bool CanHandleExtension(AZStd::string_view fileExtension) const override
+                {
+                    // The AssImp is our default provider and returns true for all registered extensions.
+                    return true;
+                }
+
+                AZStd::unique_ptr<AZ::SDKScene::SceneWrapperBase> CreateSceneWrapper() const override
+                {
+                    return AZStd::make_unique<AZ::AssImpSDKWrapper::AssImpSceneWrapper>();
+                }
+
+                AZStd::string_view GetImporterName() const override
+                {
+                    return "AssImp";
+                }
+
+            private:
+                // const AssImpSDKWrapper::AssImpSceneWrapper* m_sourceScene;
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h
@@ -60,7 +60,10 @@ namespace AZ
                     SceneNodeAddedAttributesContextBase& parent) override;
 
                 AZStd::shared_ptr<FinalizeSceneContextBase> CreateFinalizeSceneContext(
-                    Containers::Scene& scene, const SceneSystem& sourceSceneSystem, SDKScene::SceneWrapperBase& sourceScene, RenamedNodesMap& nodeNameMap) override;
+                    Containers::Scene& scene,
+                    const SceneSystem& sourceSceneSystem,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    RenamedNodesMap& nodeNameMap) override;
 
                 bool CanHandleExtension(AZStd::string_view fileExtension) const override
                 {
@@ -77,9 +80,6 @@ namespace AZ
                 {
                     return "AssImp";
                 }
-
-            private:
-                // const AssImpSDKWrapper::AssImpSceneWrapper* m_sourceScene;
             };
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.cpp
@@ -32,7 +32,7 @@ namespace AZ
                 RenamedNodesMap& nodeNameMap,
                 AssImpSDKWrapper::AssImpNodeWrapper& sourceNode)
                 : AssImpImportContext(sourceScene, sourceSceneSystem, sourceNode)
-                , NodeEncounteredContext(scene, currentGraphPosition, nodeNameMap)
+                , NodeEncounteredContextBase(scene, currentGraphPosition, nodeNameMap)
             {
             }
 
@@ -44,7 +44,7 @@ namespace AZ
                 RenamedNodesMap& nodeNameMap,
                 AssImpSDKWrapper::AssImpNodeWrapper& sourceNode)
                 : AssImpImportContext(sourceScene, sourceSceneSystem, sourceNode)
-                , NodeEncounteredContext(parent.GetScene(), currentGraphPosition, nodeNameMap)
+                , NodeEncounteredContextBase(parent.GetScene(), currentGraphPosition, nodeNameMap)
             {
             }
 

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.cpp
@@ -32,7 +32,7 @@ namespace AZ
                 RenamedNodesMap& nodeNameMap,
                 AssImpSDKWrapper::AssImpNodeWrapper& sourceNode)
                 : AssImpImportContext(sourceScene, sourceSceneSystem, sourceNode)
-                , NodeEncounteredContextBase(scene, currentGraphPosition, nodeNameMap)
+                , NodeEncounteredContext(scene, currentGraphPosition, nodeNameMap)
             {
             }
 
@@ -44,7 +44,7 @@ namespace AZ
                 RenamedNodesMap& nodeNameMap,
                 AssImpSDKWrapper::AssImpNodeWrapper& sourceNode)
                 : AssImpImportContext(sourceScene, sourceSceneSystem, sourceNode)
-                , NodeEncounteredContextBase(parent.GetScene(), currentGraphPosition, nodeNameMap)
+                , NodeEncounteredContext(parent.GetScene(), currentGraphPosition, nodeNameMap)
             {
             }
 

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
@@ -50,9 +50,9 @@ namespace AZ
             //  importers that have means to process the contained data should do so
             struct AssImpNodeEncounteredContext
                 : public AssImpImportContext
-                , public NodeEncounteredContext
+                , public NodeEncounteredContextBase
             {
-                AZ_RTTI(AssImpNodeEncounteredContext, "{C2305BC5-EAEC-4515-BAD6-45E63C3FBD3D}", AssImpImportContext, NodeEncounteredContext);
+                AZ_RTTI(AssImpNodeEncounteredContext, "{C2305BC5-EAEC-4515-BAD6-45E63C3FBD3D}", AssImpImportContext, NodeEncounteredContextBase);
 
                 AssImpNodeEncounteredContext(Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
@@ -180,4 +180,3 @@ namespace AZ
         } // namespace SceneBuilder
     } // namespace SceneAPI
 } // namespace AZ
-

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h
@@ -50,9 +50,9 @@ namespace AZ
             //  importers that have means to process the contained data should do so
             struct AssImpNodeEncounteredContext
                 : public AssImpImportContext
-                , public NodeEncounteredContextBase
+                , public NodeEncounteredContext
             {
-                AZ_RTTI(AssImpNodeEncounteredContext, "{C2305BC5-EAEC-4515-BAD6-45E63C3FBD3D}", AssImpImportContext, NodeEncounteredContextBase);
+                AZ_RTTI(AssImpNodeEncounteredContext, "{C2305BC5-EAEC-4515-BAD6-45E63C3FBD3D}", AssImpImportContext, NodeEncounteredContext);
 
                 AssImpNodeEncounteredContext(Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include "ImportContexts.h"
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <SceneAPI/SDKWrapper/NodeWrapper.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h>
+#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
+
+namespace AZ::SDKScene
+{
+    class SceneWrapperBase;
+}
+namespace AZ::SDKNode
+{
+    class NodeWrapper;
+}
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        class SceneSystem;
+        namespace SceneBuilder
+        {
+            class RenamedNodesMap;
+
+            // ImportContextProvider realizes factory pattern and provides classes specialized for particular Scene Import library.
+            struct ImportContextProvider
+            {
+                AZ_RTTI(ImportContextProvider, "{5df22f6c-8a43-417d-b735-9d9d7d069efc}");
+
+                virtual ~ImportContextProvider() = default;
+
+                virtual AZStd::shared_ptr<NodeEncounteredContextBase> CreateNodeEncounteredContext(
+                    Containers::Scene& scene,
+                    Containers::SceneGraph::NodeIndex currentGraphPosition,
+                    const SceneSystem& sourceSceneSystem,
+                    RenamedNodesMap& nodeNameMap,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    AZ::SDKNode::NodeWrapper& sourceNode) = 0;
+
+                virtual AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
+                    NodeEncounteredContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
+                    const AZStd::string& dataName) = 0;
+
+                 virtual AZStd::shared_ptr<SceneNodeAppendedContextBase> CreateSceneNodeAppendedContext(
+                    SceneDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) = 0;
+
+                virtual AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> CreateSceneAttributeDataPopulatedContext(
+                    SceneNodeAppendedContextBase& parent,
+                    AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
+                    const Containers::SceneGraph::NodeIndex attributeNodeIndex,
+                    const AZStd::string& dataName) = 0;
+
+                virtual AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> CreateSceneAttributeNodeAppendedContext(
+                    SceneAttributeDataPopulatedContextBase& parent, Containers::SceneGraph::NodeIndex newIndex) = 0;
+
+                virtual AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> CreateSceneNodeAddedAttributesContext(
+                    SceneNodeAppendedContextBase& parent) = 0;
+
+                virtual AZStd::shared_ptr<SceneNodeFinalizeContextBase> CreateSceneNodeFinalizeContext(
+                    SceneNodeAddedAttributesContextBase& parent) = 0;
+
+                virtual AZStd::shared_ptr<FinalizeSceneContextBase> CreateFinalizeSceneContext(
+                    Containers::Scene& scene,
+                    const SceneSystem& sourceSceneSystem,
+                    SDKScene::SceneWrapperBase& sourceScene,
+                    RenamedNodesMap& nodeNameMap) = 0;
+
+                // Creates an instance of the scene wrapper
+                virtual AZStd::unique_ptr<SDKScene::SceneWrapperBase> CreateSceneWrapper() const = 0;
+
+                // Checks if this provider can handle the given file extension
+                virtual bool CanHandleExtension(AZStd::string_view fileExtension) const = 0;
+
+                // Get a descriptive name for Context Provider
+                virtual AZStd::string_view GetImporterName() const { return "Unknown Importer"; }
+            };
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
@@ -14,7 +14,7 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzCore/std/string/string.h>
 #include <SceneAPI/SDKWrapper/NodeWrapper.h>
-#include <SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 
 namespace AZ::SDKScene
@@ -29,11 +29,22 @@ namespace AZ
 {
     namespace SceneAPI
     {
-        class SceneSystem;
+        namespace Containers
+        {
+            class Scene;
+        }
+
         namespace SceneBuilder
         {
             class RenamedNodesMap;
-
+            struct NodeEncounteredContextBase;
+            struct SceneDataPopulatedContextBase;
+            struct SceneNodeAppendedContextBase;
+            struct SceneAttributeDataPopulatedContextBase;
+            struct SceneAttributeNodeAppendedContextBase;
+            struct SceneNodeAddedAttributesContextBase;
+            struct SceneNodeFinalizeContextBase;
+            struct FinalizeSceneContextBase;
             // ImportContextProvider realizes factory pattern and provides classes specialized for particular Scene Import library.
             struct ImportContextProvider
             {

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h
@@ -37,7 +37,7 @@ namespace AZ
         namespace SceneBuilder
         {
             class RenamedNodesMap;
-            struct NodeEncounteredContextBase;
+            struct NodeEncounteredContext;
             struct SceneDataPopulatedContextBase;
             struct SceneNodeAppendedContextBase;
             struct SceneAttributeDataPopulatedContextBase;
@@ -52,7 +52,7 @@ namespace AZ
 
                 virtual ~ImportContextProvider() = default;
 
-                virtual AZStd::shared_ptr<NodeEncounteredContextBase> CreateNodeEncounteredContext(
+                virtual AZStd::shared_ptr<NodeEncounteredContext> CreateNodeEncounteredContext(
                     Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     const SceneSystem& sourceSceneSystem,
@@ -61,7 +61,7 @@ namespace AZ
                     AZ::SDKNode::NodeWrapper& sourceNode) = 0;
 
                 virtual AZStd::shared_ptr<SceneDataPopulatedContextBase> CreateSceneDataPopulatedContext(
-                    NodeEncounteredContextBase& parent,
+                    NodeEncounteredContext& parent,
                     AZStd::shared_ptr<DataTypes::IGraphObject> graphData,
                     const AZStd::string& dataName) = 0;
 

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
@@ -21,12 +21,14 @@ namespace AZ
                 : m_scene(scene)
                 , m_currentGraphPosition(currentGraphPosition)
                 , m_nodeNameMap(nodeNameMap)
+                , m_contextProvider(nullptr)
             {
             }
 
             ImportContext::ImportContext(Containers::Scene& scene, RenamedNodesMap& nodeNameMap)
                 : m_scene(scene)
                 , m_nodeNameMap(nodeNameMap)
+                , m_contextProvider(nullptr)
             {
                 m_currentGraphPosition = Containers::SceneGraph::NodeIndex();
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
@@ -33,21 +33,21 @@ namespace AZ
                 m_currentGraphPosition = Containers::SceneGraph::NodeIndex();
             }
 
-            NodeEncounteredContextBase::NodeEncounteredContextBase(Containers::Scene& scene,
+            NodeEncounteredContext::NodeEncounteredContext(Containers::Scene& scene,
                 Containers::SceneGraph::NodeIndex currentGraphPosition,
                 RenamedNodesMap& nodeNameMap)
                 : ImportContext(scene, currentGraphPosition, nodeNameMap)
             {
             }
 
-            NodeEncounteredContextBase::NodeEncounteredContextBase(
+            NodeEncounteredContext::NodeEncounteredContext(
                 Events::ImportEventContext& parent, Containers::SceneGraph::NodeIndex currentGraphPosition,
                 RenamedNodesMap& nodeNameMap)
                 : ImportContext(parent.GetScene(), currentGraphPosition, nodeNameMap)
             {
             }
 
-            SceneDataPopulatedContextBase::SceneDataPopulatedContextBase(NodeEncounteredContextBase& parent,
+            SceneDataPopulatedContextBase::SceneDataPopulatedContextBase(NodeEncounteredContext& parent,
                 AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
                 : ImportContext(parent.m_scene, parent.m_currentGraphPosition, parent.m_nodeNameMap)
                 , m_graphData(AZStd::move(graphData))

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.cpp
@@ -31,21 +31,21 @@ namespace AZ
                 m_currentGraphPosition = Containers::SceneGraph::NodeIndex();
             }
 
-            NodeEncounteredContext::NodeEncounteredContext(Containers::Scene& scene,
+            NodeEncounteredContextBase::NodeEncounteredContextBase(Containers::Scene& scene,
                 Containers::SceneGraph::NodeIndex currentGraphPosition,
                 RenamedNodesMap& nodeNameMap)
                 : ImportContext(scene, currentGraphPosition, nodeNameMap)
             {
             }
 
-            NodeEncounteredContext::NodeEncounteredContext(
+            NodeEncounteredContextBase::NodeEncounteredContextBase(
                 Events::ImportEventContext& parent, Containers::SceneGraph::NodeIndex currentGraphPosition,
                 RenamedNodesMap& nodeNameMap)
                 : ImportContext(parent.GetScene(), currentGraphPosition, nodeNameMap)
             {
             }
 
-            SceneDataPopulatedContextBase::SceneDataPopulatedContextBase(NodeEncounteredContext& parent,
+            SceneDataPopulatedContextBase::SceneDataPopulatedContextBase(NodeEncounteredContextBase& parent,
                 AZStd::shared_ptr<DataTypes::IGraphObject> graphData, const AZStd::string& dataName)
                 : ImportContext(parent.m_scene, parent.m_currentGraphPosition, parent.m_nodeNameMap)
                 , m_graphData(AZStd::move(graphData))

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
+#include "ImportContextProvider.h"
+
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
-#include <SceneAPI/SceneCore/Events/CallProcessorBus.h>
-#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
-
+#include <SceneAPI/SceneCore/Containers/SceneGraph.h>
+#include <SceneAPI/SceneCore/Events/CallProcessorBus.h>
 
 namespace AZ
 {    
@@ -36,6 +37,7 @@ namespace AZ
 
         namespace SceneBuilder
         {
+            struct ImportContextProvider;
             class RenamedNodesMap;
 
             //  ImportContext
@@ -52,6 +54,7 @@ namespace AZ
                 Containers::Scene& m_scene;
                 Containers::SceneGraph::NodeIndex m_currentGraphPosition;
                 RenamedNodesMap& m_nodeNameMap; // Map of the nodes that have received a new name.
+                ImportContextProvider* m_contextProvider; // The provider that created this context.
             };
 
             //  Context pushed to indicate that a new Node has been found and any

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
@@ -57,21 +57,22 @@ namespace AZ
                 ImportContextProvider* m_contextProvider; // The provider that created this context.
             };
 
+            //  NodeEncounteredContext
             //  Context pushed to indicate that a new Node has been found and any
             //  importers that have means to process the contained data should do so
             //  Member Variables:
             //      m_createdData - out container that importers must add their created data
             //          to.
-            struct NodeEncounteredContextBase
+            struct NodeEncounteredContext
                 : public ImportContext
             {
-                AZ_RTTI(NodeEncounteredContextBase, "{40C31D76-7101-4ACD-8849-0D6D0AF62855}", ImportContext);
+                AZ_RTTI(NodeEncounteredContext, "{40C31D76-7101-4ACD-8849-0D6D0AF62855}", ImportContext);
 
-                NodeEncounteredContextBase(Containers::Scene& scene,
+                NodeEncounteredContext(Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     RenamedNodesMap& nodeNameMap);
 
-                NodeEncounteredContextBase(Events::ImportEventContext& parent,
+                NodeEncounteredContext(Events::ImportEventContext& parent,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     RenamedNodesMap& nodeNameMap);
 
@@ -91,7 +92,7 @@ namespace AZ
             {
                 AZ_RTTI(SceneDataPopulatedContextBase, "{5F4CE8D2-EEAC-49F7-8065-0B6372162D6F}", ImportContext);
 
-                SceneDataPopulatedContextBase(NodeEncounteredContextBase& parent,
+                SceneDataPopulatedContextBase(NodeEncounteredContext& parent,
                     AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
                     const AZStd::string& dataName);
 

--- a/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h
@@ -54,22 +54,21 @@ namespace AZ
                 RenamedNodesMap& m_nodeNameMap; // Map of the nodes that have received a new name.
             };
 
-            //  NodeEncounteredContext
             //  Context pushed to indicate that a new Node has been found and any
             //  importers that have means to process the contained data should do so
             //  Member Variables:
             //      m_createdData - out container that importers must add their created data
             //          to.
-            struct NodeEncounteredContext
+            struct NodeEncounteredContextBase
                 : public ImportContext
             {
-                AZ_RTTI(NodeEncounteredContext, "{40C31D76-7101-4ACD-8849-0D6D0AF62855}", ImportContext);
+                AZ_RTTI(NodeEncounteredContextBase, "{40C31D76-7101-4ACD-8849-0D6D0AF62855}", ImportContext);
 
-                NodeEncounteredContext(Containers::Scene& scene,
+                NodeEncounteredContextBase(Containers::Scene& scene,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     RenamedNodesMap& nodeNameMap);
 
-                NodeEncounteredContext(Events::ImportEventContext& parent,
+                NodeEncounteredContextBase(Events::ImportEventContext& parent,
                     Containers::SceneGraph::NodeIndex currentGraphPosition,
                     RenamedNodesMap& nodeNameMap);
 
@@ -89,7 +88,7 @@ namespace AZ
             {
                 AZ_RTTI(SceneDataPopulatedContextBase, "{5F4CE8D2-EEAC-49F7-8065-0B6372162D6F}", ImportContext);
 
-                SceneDataPopulatedContextBase(NodeEncounteredContext& parent,
+                SceneDataPopulatedContextBase(NodeEncounteredContextBase& parent,
                     AZStd::shared_ptr<DataTypes::IGraphObject> nodeData,
                     const AZStd::string& dataName);
 
@@ -177,4 +176,3 @@ namespace AZ
         } // namespace SceneBuilder
     } // namespace SceneAPI
 } // namespace AZ
-

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
@@ -116,12 +116,12 @@ namespace AZ
                     context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, m_defaultNodeName);
 
                 Events::ProcessingResult bitangentResults;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, bitangentStream, newIndex, m_defaultNodeName);
-                bitangentResults = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, bitangentStream, newIndex, m_defaultNodeName);
+                bitangentResults = Events::Process(*dataPopulated);
 
                 if (bitangentResults != Events::ProcessingResult::Failure)
                 {
-                    bitangentResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                    bitangentResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
                 return bitangentResults;
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
@@ -285,12 +285,12 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, nodeName.c_str());
 
                     Events::ProcessingResult blendShapeResult;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, blendShapeData, newIndex, nodeName);
-                    blendShapeResult = Events::Process(dataPopulated);
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, blendShapeData, newIndex, nodeName);
+                    blendShapeResult = Events::Process(*dataPopulated);
 
                     if (blendShapeResult != Events::ProcessingResult::Failure)
                     {
-                        blendShapeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                        blendShapeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
                     combinedBlendShapeResult += blendShapeResult;
                 }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
@@ -113,12 +113,13 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, nodeName.c_str());
 
                     Events::ProcessingResult colorMapResults;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, vertexColors, newIndex, nodeName.c_str());
-                    colorMapResults = Events::Process(dataPopulated);
+                    AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> dataPopulated =
+                        context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, vertexColors, newIndex, nodeName.c_str());
+                    colorMapResults = Events::Process(*dataPopulated);
 
                     if (colorMapResults != Events::ProcessingResult::Failure)
                     {
-                        colorMapResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                        colorMapResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
 
                     combinedVertexColorResults += colorMapResults;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpColorStreamImporter.cpp
@@ -113,8 +113,7 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, nodeName.c_str());
 
                     Events::ProcessingResult colorMapResults;
-                    AZStd::shared_ptr<SceneAttributeDataPopulatedContextBase> dataPopulated =
-                        context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, vertexColors, newIndex, nodeName.c_str());
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, vertexColors, newIndex, nodeName.c_str());
                     colorMapResults = Events::Process(*dataPopulated);
 
                     if (colorMapResults != Events::ProcessingResult::Failure)

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpCustomPropertyImporter.cpp
@@ -114,12 +114,12 @@ namespace AZ::SceneAPI::SceneBuilder
                 }
 
                 Events::ProcessingResult attributeResult;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, customPropertyMapData, newIndex, nodeName);
-                attributeResult = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, customPropertyMapData, newIndex, nodeName);
+                attributeResult = Events::Process(*dataPopulated);
 
                 if (attributeResult != Events::ProcessingResult::Failure)
                 {
-                    attributeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                    attributeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
 
                 return attributeResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.cpp
@@ -156,12 +156,12 @@ namespace AZ
                             continue;
                         }
 
-                        AssImpSceneAttributeDataPopulatedContext dataPopulated(context, material, newIndex, materialName);
-                        materialResult = Events::Process(dataPopulated);
+                        auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, material, newIndex, materialName);
+                        materialResult = Events::Process(*dataPopulated);
 
                         if (materialResult != Events::ProcessingResult::Failure)
                         {
-                            materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(dataPopulated);
+                            materialResult = SceneAPI::SceneBuilder::AddAttributeDataNodeWithContexts(*dataPopulated);
                         }
 
                         combinedMaterialImportResults += materialResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.h>
@@ -17,8 +19,6 @@
 #include <SceneAPI/SceneCore/Events/ImportEventContext.h>
 #include <SceneAPI/SceneData/GraphData/MeshData.h>
 #include <SceneAPI/SceneData/GraphData/SkinWeightData.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 
 namespace AZ
 {
@@ -49,7 +49,7 @@ namespace AZ
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
 
-                if(currentNode->mNumMeshes <= 0)
+                if (currentNode->mNumMeshes <= 0)
                 {
                     return Events::ProcessingResult::Ignored;
                 }
@@ -64,16 +64,16 @@ namespace AZ
                 const uint64_t totalVertices = GetVertexCountForAllMeshesOnNode(*currentNode, *scene);
 
                 int vertexCount = 0;
-                for(unsigned nodeMeshIndex = 0; nodeMeshIndex < currentNode->mNumMeshes; ++nodeMeshIndex)
+                for (unsigned nodeMeshIndex = 0; nodeMeshIndex < currentNode->mNumMeshes; ++nodeMeshIndex)
                 {
                     int sceneMeshIndex = currentNode->mMeshes[nodeMeshIndex];
                     const aiMesh* mesh = scene->mMeshes[sceneMeshIndex];
 
-                    for(unsigned b = 0; b < mesh->mNumBones; ++b)
+                    for (unsigned b = 0; b < mesh->mNumBones; ++b)
                     {
                         const aiBone* bone = mesh->mBones[b];
 
-                        if(bone->mNumWeights <= 0)
+                        if (bone->mNumWeights <= 0)
                         {
                             continue;
                         }
@@ -86,7 +86,8 @@ namespace AZ
                             weightsIndexForMesh =
                                 context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, skinWeightName.c_str());
 
-                            AZ_Error("SkinWeightsImporter", weightsIndexForMesh.IsValid(), "Failed to create SceneGraph node for attribute.");
+                            AZ_Error(
+                                "SkinWeightsImporter", weightsIndexForMesh.IsValid(), "Failed to create SceneGraph node for attribute.");
                             if (!weightsIndexForMesh.IsValid())
                             {
                                 combinedSkinWeightsResult += Events::ProcessingResult::Failure;
@@ -111,12 +112,13 @@ namespace AZ
                 }
 
                 Events::ProcessingResult skinWeightsResult;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, skinWeightData, weightsIndexForMesh, skinWeightName);
-                skinWeightsResult = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(
+                    context, skinWeightData, weightsIndexForMesh, skinWeightName);
+                skinWeightsResult = Events::Process(*dataPopulated);
 
                 if (skinWeightsResult != Events::ProcessingResult::Failure)
                 {
-                    skinWeightsResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                    skinWeightsResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
 
                 combinedSkinWeightsResult += skinWeightsResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.cpp
@@ -10,8 +10,6 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpSkinWeightsImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.h>
@@ -19,6 +17,8 @@
 #include <SceneAPI/SceneCore/Events/ImportEventContext.h>
 #include <SceneAPI/SceneData/GraphData/MeshData.h>
 #include <SceneAPI/SceneData/GraphData/SkinWeightData.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 
 namespace AZ
 {
@@ -49,7 +49,7 @@ namespace AZ
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
 
-                if (currentNode->mNumMeshes <= 0)
+                if(currentNode->mNumMeshes <= 0)
                 {
                     return Events::ProcessingResult::Ignored;
                 }
@@ -64,16 +64,16 @@ namespace AZ
                 const uint64_t totalVertices = GetVertexCountForAllMeshesOnNode(*currentNode, *scene);
 
                 int vertexCount = 0;
-                for (unsigned nodeMeshIndex = 0; nodeMeshIndex < currentNode->mNumMeshes; ++nodeMeshIndex)
+                for(unsigned nodeMeshIndex = 0; nodeMeshIndex < currentNode->mNumMeshes; ++nodeMeshIndex)
                 {
                     int sceneMeshIndex = currentNode->mMeshes[nodeMeshIndex];
                     const aiMesh* mesh = scene->mMeshes[sceneMeshIndex];
 
-                    for (unsigned b = 0; b < mesh->mNumBones; ++b)
+                    for(unsigned b = 0; b < mesh->mNumBones; ++b)
                     {
                         const aiBone* bone = mesh->mBones[b];
 
-                        if (bone->mNumWeights <= 0)
+                        if(bone->mNumWeights <= 0)
                         {
                             continue;
                         }
@@ -86,8 +86,7 @@ namespace AZ
                             weightsIndexForMesh =
                                 context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, skinWeightName.c_str());
 
-                            AZ_Error(
-                                "SkinWeightsImporter", weightsIndexForMesh.IsValid(), "Failed to create SceneGraph node for attribute.");
+                            AZ_Error("SkinWeightsImporter", weightsIndexForMesh.IsValid(), "Failed to create SceneGraph node for attribute.");
                             if (!weightsIndexForMesh.IsValid())
                             {
                                 combinedSkinWeightsResult += Events::ProcessingResult::Failure;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
@@ -10,18 +10,18 @@
 #include <AzCore/std/numeric.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.h>
-#include <SceneAPI/SceneCore/Utilities/Reporting.h>
-#include <SceneAPI/SceneData/GraphData/MeshData.h>
 #include <SceneAPI/SceneData/GraphData/MeshVertexTangentData.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
+#include <SceneAPI/SceneData/GraphData/MeshData.h>
+#include <SceneAPI/SceneCore/Utilities/Reporting.h>
 
-#include <assimp/mesh.h>
 #include <assimp/scene.h>
+#include <assimp/mesh.h>
 
 namespace AZ
 {
@@ -54,34 +54,30 @@ namespace AZ
                 }
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
-
                 const auto meshHasTangentsAndBitangents = [&scene](const unsigned int meshIndex)
                 {
                     return scene->mMeshes[meshIndex]->HasTangentsAndBitangents();
                 };
 
                 // If there are no tangents on any meshes, there's nothing to import in this function.
-                const bool anyMeshHasTangentsAndBitangents =
-                    AZStd::any_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
+                const bool anyMeshHasTangentsAndBitangents = AZStd::any_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
                 if (!anyMeshHasTangentsAndBitangents)
                 {
                     return Events::ProcessingResult::Ignored;
                 }
 
                 // AssImp nodes with multiple meshes on them occur when AssImp split a mesh on material.
-                // This logic recombines those meshes to minimize the changes needed to replace FBX SDK with AssImp, FBX SDK did not
-                // separate meshes, and the engine has code to do this later.
-                const bool allMeshesHaveTangentsAndBitangents =
-                    AZStd::all_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
+                // This logic recombines those meshes to minimize the changes needed to replace FBX SDK with AssImp, FBX SDK did not separate meshes,
+                // and the engine has code to do this later.
+                const bool allMeshesHaveTangentsAndBitangents = AZStd::all_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
                 if (!allMeshesHaveTangentsAndBitangents)
                 {
                     AZ_Error(
-                        Utilities::ErrorWindow,
-                        false,
+                        Utilities::ErrorWindow, false,
                         "Node with name %s has meshes with and without tangents. "
-                        "Placeholder incorrect tangents will be generated to allow the data to process, "
-                        "but the source art needs to be fixed to correct this. Either apply tangents to all meshes on this node, "
-                        "or remove all tangents from all meshes on this node.",
+                            "Placeholder incorrect tangents will be generated to allow the data to process, "
+                            "but the source art needs to be fixed to correct this. Either apply tangents to all meshes on this node, "
+                            "or remove all tangents from all meshes on this node.",
                         currentNode->mName.C_Str());
                 }
 
@@ -110,7 +106,8 @@ namespace AZ
                         }
                         else
                         {
-                            const Vector4 tangent(AssImpSDKWrapper::AssImpTypeConverter::ToVector3(mesh->mTangents[v]));
+                            const Vector4 tangent(
+                                AssImpSDKWrapper::AssImpTypeConverter::ToVector3(mesh->mTangents[v]));
                             tangentStream->AppendTangent(tangent);
                         }
                     }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
@@ -10,18 +10,18 @@
 #include <AzCore/std/numeric.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.h>
-#include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
-#include <SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.h>
-#include <SceneAPI/SceneData/GraphData/MeshVertexTangentData.h>
 #include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
-#include <SceneAPI/SceneData/GraphData/MeshData.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.h>
+#include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
+#include <SceneAPI/SceneBuilder/Importers/Utilities/AssImpMeshImporterUtilities.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
+#include <SceneAPI/SceneData/GraphData/MeshData.h>
+#include <SceneAPI/SceneData/GraphData/MeshVertexTangentData.h>
 
-#include <assimp/scene.h>
 #include <assimp/mesh.h>
+#include <assimp/scene.h>
 
 namespace AZ
 {
@@ -54,31 +54,34 @@ namespace AZ
                 }
                 const aiNode* currentNode = context.m_sourceNode.GetAssImpNode();
                 const aiScene* scene = context.m_sourceScene.GetAssImpScene();
-                
+
                 const auto meshHasTangentsAndBitangents = [&scene](const unsigned int meshIndex)
                 {
                     return scene->mMeshes[meshIndex]->HasTangentsAndBitangents();
                 };
 
                 // If there are no tangents on any meshes, there's nothing to import in this function.
-                const bool anyMeshHasTangentsAndBitangents = AZStd::any_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
+                const bool anyMeshHasTangentsAndBitangents =
+                    AZStd::any_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
                 if (!anyMeshHasTangentsAndBitangents)
                 {
                     return Events::ProcessingResult::Ignored;
                 }
 
                 // AssImp nodes with multiple meshes on them occur when AssImp split a mesh on material.
-                // This logic recombines those meshes to minimize the changes needed to replace FBX SDK with AssImp, FBX SDK did not separate meshes,
-                // and the engine has code to do this later.
-                const bool allMeshesHaveTangentsAndBitangents = AZStd::all_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
+                // This logic recombines those meshes to minimize the changes needed to replace FBX SDK with AssImp, FBX SDK did not
+                // separate meshes, and the engine has code to do this later.
+                const bool allMeshesHaveTangentsAndBitangents =
+                    AZStd::all_of(currentNode->mMeshes, currentNode->mMeshes + currentNode->mNumMeshes, meshHasTangentsAndBitangents);
                 if (!allMeshesHaveTangentsAndBitangents)
                 {
                     AZ_Error(
-                        Utilities::ErrorWindow, false,
+                        Utilities::ErrorWindow,
+                        false,
                         "Node with name %s has meshes with and without tangents. "
-                            "Placeholder incorrect tangents will be generated to allow the data to process, "
-                            "but the source art needs to be fixed to correct this. Either apply tangents to all meshes on this node, "
-                            "or remove all tangents from all meshes on this node.",
+                        "Placeholder incorrect tangents will be generated to allow the data to process, "
+                        "but the source art needs to be fixed to correct this. Either apply tangents to all meshes on this node, "
+                        "or remove all tangents from all meshes on this node.",
                         currentNode->mName.C_Str());
                 }
 
@@ -107,8 +110,7 @@ namespace AZ
                         }
                         else
                         {
-                            const Vector4 tangent(
-                                AssImpSDKWrapper::AssImpTypeConverter::ToVector3(mesh->mTangents[v]));
+                            const Vector4 tangent(AssImpSDKWrapper::AssImpTypeConverter::ToVector3(mesh->mTangents[v]));
                             tangentStream->AppendTangent(tangent);
                         }
                     }
@@ -118,12 +120,13 @@ namespace AZ
                     context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, m_defaultNodeName);
 
                 Events::ProcessingResult tangentResults;
-                AssImpSceneAttributeDataPopulatedContext dataPopulated(context, tangentStream, newIndex, m_defaultNodeName);
-                tangentResults = Events::Process(dataPopulated);
+                auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(
+                    context, tangentStream, newIndex, m_defaultNodeName);
+                tangentResults = Events::Process(*dataPopulated);
 
                 if (tangentResults != Events::ProcessingResult::Failure)
                 {
-                    tangentResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                    tangentResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                 }
                 return tangentResults;
             }

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
@@ -7,19 +7,19 @@
  */
 #include <SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.h>
 
-#include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SceneBuilder/SceneSystem.h>
-#include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
-#include <SceneAPI/SceneBuilder/Importers/Utilities/RenamedNodesMap.h>
-#include <SceneAPI/SceneCore/Utilities/Reporting.h>
-#include <SceneAPI/SceneData/GraphData/TransformData.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
 #include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <assimp/scene.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
 #include <SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.h>
+#include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
+#include <SceneAPI/SceneBuilder/Importers/Utilities/RenamedNodesMap.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
+#include <SceneAPI/SceneCore/Utilities/Reporting.h>
+#include <SceneAPI/SceneData/GraphData/TransformData.h>
+#include <assimp/scene.h>
 
 namespace AZ
 {
@@ -86,12 +86,13 @@ namespace AZ
                         }
 
                         Events::ProcessingResult transformAttributeResult;
-                        AssImpSceneAttributeDataPopulatedContext dataPopulated(context, transformData, newIndex, nodeName);
-                        transformAttributeResult = Events::Process(dataPopulated);
+                        auto dataPopulated =
+                            context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, transformData, newIndex, nodeName);
+                        transformAttributeResult = Events::Process(*dataPopulated);
 
                         if (transformAttributeResult != Events::ProcessingResult::Failure)
                         {
-                            transformAttributeResult = AddAttributeDataNodeWithContexts(dataPopulated);
+                            transformAttributeResult = AddAttributeDataNodeWithContexts(*dataPopulated);
                         }
 
                         return transformAttributeResult;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.cpp
@@ -7,19 +7,19 @@
  */
 #include <SceneAPI/SceneBuilder/Importers/AssImpTransformImporter.h>
 
-#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneBuilder/Importers/Utilities/RenamedNodesMap.h>
-#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <SceneAPI/SceneData/GraphData/TransformData.h>
+#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
+#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
+#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
 #include <assimp/scene.h>
+#include <SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.h>
 
 namespace AZ
 {

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpUvMapImporter.cpp
@@ -161,12 +161,12 @@ namespace AZ
                         context.m_scene.GetGraph().AddChild(context.m_currentGraphPosition, name.c_str());
 
                     Events::ProcessingResult uvMapResults;
-                    AssImpSceneAttributeDataPopulatedContext dataPopulated(context, uvMap, newIndex, name);
-                    uvMapResults = Events::Process(dataPopulated);
+                    auto dataPopulated = context.m_contextProvider->CreateSceneAttributeDataPopulatedContext(context, uvMap, newIndex, name);
+                    uvMapResults = Events::Process(*dataPopulated);
 
                     if (uvMapResults != Events::ProcessingResult::Failure)
                     {
-                        uvMapResults = AddAttributeDataNodeWithContexts(dataPopulated);
+                        uvMapResults = AddAttributeDataNodeWithContexts(*dataPopulated);
                     }
 
                     combinedUvMapResults += uvMapResults;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
 #include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
@@ -30,6 +31,7 @@ namespace AZ
         {
             static const float g_sceneUtilityEqualityEpsilon = 0.001f;
 
+            //TODO: this function should be generic
             CoreProcessingResult AddDataNodeWithContexts(SceneDataPopulatedContextBase& dataPopulated)
             {
                 AZ_TraceContext("Node Name", dataPopulated.m_dataName);
@@ -42,22 +44,32 @@ namespace AZ
                 dataPopulated.m_scene.GetGraph().SetContent(dataPopulated.m_currentGraphPosition,
                     AZStd::move(dataPopulated.m_graphData));
 
-                if (azrtti_istypeof<AssImpSceneDataPopulatedContext>(dataPopulated))
+                // Use context provider to create the appropriate context objects
+                AZStd::shared_ptr<SceneNodeAppendedContextBase> nodeAppended = 
+                    dataPopulated.m_contextProvider->CreateSceneNodeAppendedContext(dataPopulated, dataPopulated.m_currentGraphPosition);
+                if (nodeAppended)
                 {
-                    AssImpSceneDataPopulatedContext* dataPopulatedContext = azrtti_cast<AssImpSceneDataPopulatedContext*>(&dataPopulated);
-                    AssImpSceneNodeAppendedContext nodeAppended(*dataPopulatedContext, dataPopulated.m_currentGraphPosition);
-                    nodeResults += Events::Process(nodeAppended);
+                    nodeResults += Events::Process(*nodeAppended);
 
-                    AssImpSceneNodeAddedAttributesContext addedAttributes(nodeAppended);
-                    nodeResults += Events::Process(addedAttributes);
+                    AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> addedAttributes = 
+                        dataPopulated.m_contextProvider->CreateSceneNodeAddedAttributesContext(*nodeAppended);
+                    if (addedAttributes)
+                    {
+                        nodeResults += Events::Process(*addedAttributes);
 
-                    AssImpSceneNodeFinalizeContext finalizeNode(addedAttributes);
-                    nodeResults += Events::Process(finalizeNode);
+                        AZStd::shared_ptr<SceneNodeFinalizeContextBase> finalizeNode = 
+                            dataPopulated.m_contextProvider->CreateSceneNodeFinalizeContext(*addedAttributes);
+                        if (finalizeNode)
+                        {
+                            nodeResults += Events::Process(*finalizeNode);
+                        }
+                    }
                 }
 
                 return nodeResults.GetResult();
             }
 
+            //TODO: this function should be generic
             CoreProcessingResult AddAttributeDataNodeWithContexts(SceneAttributeDataPopulatedContextBase& dataPopulated)
             {
                 AZ_TraceContext("Node Name", dataPopulated.m_dataName);
@@ -71,11 +83,13 @@ namespace AZ
 
                 dataPopulated.m_scene.GetGraph().SetContent(dataPopulated.m_currentGraphPosition,
                     AZStd::move(dataPopulated.m_graphData));
-                if (azrtti_istypeof<AssImpSceneAttributeDataPopulatedContext>(dataPopulated))
+                
+                // Use context provider to create the appropriate attribute node context
+                AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> nodeAppended = 
+                    dataPopulated.m_contextProvider->CreateSceneAttributeNodeAppendedContext(dataPopulated, dataPopulated.m_currentGraphPosition);
+                if (nodeAppended)
                 {
-                    AssImpSceneAttributeDataPopulatedContext* dataPopulatedContext = azrtti_cast<AssImpSceneAttributeDataPopulatedContext*>(&dataPopulated);
-                    AssImpSceneAttributeNodeAppendedContext nodeAppended(*dataPopulatedContext, dataPopulated.m_currentGraphPosition);
-                    nodeResults += Events::Process(nodeAppended);
+                    nodeResults += Events::Process(*nodeAppended);
                 }
 
                 return nodeResults.GetResult();

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.cpp
@@ -31,7 +31,6 @@ namespace AZ
         {
             static const float g_sceneUtilityEqualityEpsilon = 0.001f;
 
-            //TODO: this function should be generic
             CoreProcessingResult AddDataNodeWithContexts(SceneDataPopulatedContextBase& dataPopulated)
             {
                 AZ_TraceContext("Node Name", dataPopulated.m_dataName);
@@ -45,19 +44,19 @@ namespace AZ
                     AZStd::move(dataPopulated.m_graphData));
 
                 // Use context provider to create the appropriate context objects
-                AZStd::shared_ptr<SceneNodeAppendedContextBase> nodeAppended = 
+                AZStd::shared_ptr<SceneNodeAppendedContextBase> nodeAppended =
                     dataPopulated.m_contextProvider->CreateSceneNodeAppendedContext(dataPopulated, dataPopulated.m_currentGraphPosition);
                 if (nodeAppended)
                 {
                     nodeResults += Events::Process(*nodeAppended);
 
-                    AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> addedAttributes = 
+                    AZStd::shared_ptr<SceneNodeAddedAttributesContextBase> addedAttributes =
                         dataPopulated.m_contextProvider->CreateSceneNodeAddedAttributesContext(*nodeAppended);
                     if (addedAttributes)
                     {
                         nodeResults += Events::Process(*addedAttributes);
 
-                        AZStd::shared_ptr<SceneNodeFinalizeContextBase> finalizeNode = 
+                        AZStd::shared_ptr<SceneNodeFinalizeContextBase> finalizeNode =
                             dataPopulated.m_contextProvider->CreateSceneNodeFinalizeContext(*addedAttributes);
                         if (finalizeNode)
                         {
@@ -69,7 +68,6 @@ namespace AZ
                 return nodeResults.GetResult();
             }
 
-            //TODO: this function should be generic
             CoreProcessingResult AddAttributeDataNodeWithContexts(SceneAttributeDataPopulatedContextBase& dataPopulated)
             {
                 AZ_TraceContext("Node Name", dataPopulated.m_dataName);
@@ -83,9 +81,8 @@ namespace AZ
 
                 dataPopulated.m_scene.GetGraph().SetContent(dataPopulated.m_currentGraphPosition,
                     AZStd::move(dataPopulated.m_graphData));
-                
                 // Use context provider to create the appropriate attribute node context
-                AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> nodeAppended = 
+                AZStd::shared_ptr<SceneAttributeNodeAppendedContextBase> nodeAppended =
                     dataPopulated.m_contextProvider->CreateSceneAttributeNodeAppendedContext(dataPopulated, dataPopulated.m_currentGraphPosition);
                 if (nodeAppended)
                 {

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
 #include <SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
@@ -22,7 +23,7 @@ namespace AZ
     {
         namespace SceneBuilder
         {
-            struct SceneImportContext;
+            struct ImportContextProvider;
 
             using CoreScene = Containers::Scene;
             using CoreSceneGraph = Containers::SceneGraph;
@@ -30,17 +31,16 @@ namespace AZ
             using CoreProcessingResult = Events::ProcessingResult;
 
             inline bool NodeIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
-            inline bool NodeParentIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, 
-                const AZ::Uuid& uuid);
-            inline bool NodeHasAncestorOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex,
-                const AZ::Uuid& uuid);
+            inline bool NodeParentIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
+            inline bool NodeHasAncestorOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
             CoreProcessingResult AddDataNodeWithContexts(SceneDataPopulatedContextBase& dataContext);
-            CoreProcessingResult AddAttributeDataNodeWithContexts(SceneAttributeDataPopulatedContextBase& dataContext);
+            CoreProcessingResult AddAttributeDataNodeWithContexts(
+                SceneAttributeDataPopulatedContextBase& dataContext);
             bool AreSceneGraphsEqual(const CoreSceneGraph& lhsGraph, const CoreSceneGraph& rhsGraph);
             inline bool AreScenesEqual(const CoreScene& lhs, const CoreScene& rhs);
 
-            bool IsGraphDataEqual(const AZStd::shared_ptr<const DataTypes::IGraphObject>& lhs,
-                const AZStd::shared_ptr<const DataTypes::IGraphObject>& rhs);
+            bool IsGraphDataEqual(
+                const AZStd::shared_ptr<const DataTypes::IGraphObject>& lhs, const AZStd::shared_ptr<const DataTypes::IGraphObject>& rhs);
 
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/ImporterUtilities.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
 #include <SceneAPI/SceneBuilder/ImportContexts/ImportContexts.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
@@ -23,7 +22,7 @@ namespace AZ
     {
         namespace SceneBuilder
         {
-            struct ImportContextProvider;
+            struct SceneImportContext;
 
             using CoreScene = Containers::Scene;
             using CoreSceneGraph = Containers::SceneGraph;
@@ -31,16 +30,17 @@ namespace AZ
             using CoreProcessingResult = Events::ProcessingResult;
 
             inline bool NodeIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
-            inline bool NodeParentIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
-            inline bool NodeHasAncestorOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, const AZ::Uuid& uuid);
+            inline bool NodeParentIsOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex, 
+                const AZ::Uuid& uuid);
+            inline bool NodeHasAncestorOfType(const CoreSceneGraph& graph, CoreGraphNodeIndex nodeIndex,
+                const AZ::Uuid& uuid);
             CoreProcessingResult AddDataNodeWithContexts(SceneDataPopulatedContextBase& dataContext);
-            CoreProcessingResult AddAttributeDataNodeWithContexts(
-                SceneAttributeDataPopulatedContextBase& dataContext);
+            CoreProcessingResult AddAttributeDataNodeWithContexts(SceneAttributeDataPopulatedContextBase& dataContext);
             bool AreSceneGraphsEqual(const CoreSceneGraph& lhsGraph, const CoreSceneGraph& rhsGraph);
             inline bool AreScenesEqual(const CoreScene& lhs, const CoreScene& rhs);
 
-            bool IsGraphDataEqual(
-                const AZStd::shared_ptr<const DataTypes::IGraphObject>& lhs, const AZStd::shared_ptr<const DataTypes::IGraphObject>& rhs);
+            bool IsGraphDataEqual(const AZStd::shared_ptr<const DataTypes::IGraphObject>& lhs,
+                const AZStd::shared_ptr<const DataTypes::IGraphObject>& rhs);
 
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SceneBuilderSystemComponent.h"
+#include "ImportContexts/AssImpImportContextProvider.h"
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContextProvider.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            void SceneBuilderSystemComponent::Activate()
+            {
+                // Get the import context registy
+                if (auto* registry = ImportContextRegistryInterface::Get())
+                {
+                    // Create and register the ImportContextProvider for AssImp
+                    // It should be always present and be used as a fallback if no specialized provider is available
+                    auto assImpContextProvider = aznew AssImpImportContextProvider();
+                    registry->RegisterContextProvider(assImpContextProvider);
+                    AZ_Info("SceneAPI", "AssImp Import Context was registered.\n");
+                }
+                else
+                {
+                    AZ_Error("SceneAPI", false, "ImportContextRegistryInterface not found. AssImp Import Context was not registered.");
+                }
+            }
+
+            void SceneBuilderSystemComponent::Deactivate()
+            {
+            }
+
+            void SceneBuilderSystemComponent::Reflect(ReflectContext* context)
+            {
+                SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+                if (serializeContext)
+                {
+                    serializeContext->Class<SceneBuilderSystemComponent, AZ::Component>()->Version(1);
+                }
+            }
+        } // namespace SceneBuilder
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneBuilderSystemComponent.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistryManager.h>
+#include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
+
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace SceneBuilder
+        {
+            // Scene system components are components that can be used to create system components
+            //      in situations where the full initialization and/or construction of regular
+            //      system components don't apply such as in the ResourceCompilerScene.
+            class SceneBuilderSystemComponent
+                : public AZ::Component
+            {
+            public:
+                AZ_COMPONENT(SceneBuilderSystemComponent, "{9453ddf4-882c-4675-86eb-834f1d1dc5ef}");
+
+                ~SceneBuilderSystemComponent() override = default;
+
+                void Activate() override;
+                void Deactivate() override;
+
+                static void Reflect(ReflectContext* context);
+            private:
+                ImportContextRegistryManager m_sceneSystemRegistry;
+            };
+        } // namespace SceneCore
+    } // namespace SceneAPI
+} // namespace AZ

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
@@ -81,7 +81,9 @@ namespace AZ
                 Containers::Scene scene;
                 Import::ManifestImportRequestHandler manifestHandler;
                 manifestHandler.LoadAsset(
-                    scene, sourceAssetPath, Uuid::CreateNull(), Events::AssetImportRequest::RequestingApplication::AssetProcessor);
+                    scene, sourceAssetPath,
+                    Uuid::CreateNull(),
+                    Events::AssetImportRequest::RequestingApplication::AssetProcessor);
 
                 // Search for the ImportGroup. If it's there, get the new import settings. If not, we'll just use the defaults.
                 size_t count = scene.GetManifest().GetEntryCount();

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
@@ -138,11 +138,9 @@ namespace AZ
 
                 AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpSceneWrapper->GetUpVectorAndSign();
 
-                const aiAABB& aabb = assImpSceneWrapper->GetAABB();
-                aiVector3t dimension = aabb.mMax - aabb.mMin;
-                Vector3 t{ dimension.x, dimension.y, dimension.z };
-                scene.SetSceneDimension(t);
-                scene.SetSceneVertices(assImpSceneWrapper->GetVertices());
+                const AZ::Aabb& aabb = assImpSceneWrapper->GetAABB();
+                scene.SetSceneDimension(aabb.GetExtents());
+                scene.SetSceneVertices(assImpSceneWrapper->GetVerticesCount());
 
                 if (upAxisAndSign.second <= 0)
                 {

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.cpp
@@ -12,23 +12,21 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/containers/queue.h>
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/string/conversions.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzCore/std/string/string.h>
 #include <AzToolsFramework/Debug/TraceContext.h>
-#include <SceneAPI/SceneBuilder/SceneImporter.h>
-#include <SceneAPI/SceneBuilder/ImportContexts/AssImpImportContexts.h>
-#include <SceneAPI/SceneBuilder/Importers/AssImpMaterialImporter.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistry.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
 #include <SceneAPI/SceneBuilder/Importers/ImporterUtilities.h>
 #include <SceneAPI/SceneBuilder/Importers/Utilities/RenamedNodesMap.h>
+#include <SceneAPI/SceneBuilder/SceneImporter.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 #include <SceneAPI/SceneCore/DataTypes/Groups/IImportGroup.h>
 #include <SceneAPI/SceneCore/Import/ManifestImportRequestHandler.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
 #include <SceneAPI/SceneData/GraphData/TransformData.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpNodeWrapper.h>
-
 
 namespace AZ
 {
@@ -51,8 +49,10 @@ namespace AZ
 
             SceneImporter::SceneImporter()
                 : m_sceneSystem(new SceneSystem())
+                , m_contextProvider(nullptr)
+                , m_sceneWrapper(nullptr)
             {
-                m_sceneWrapper = AZStd::make_unique<AssImpSDKWrapper::AssImpSceneWrapper>();
+                m_sceneWrapper = AZStd::make_unique<SDKScene::SceneWrapperBase>();
                 BindToCall(&SceneImporter::ImportProcessing);
             }
 
@@ -81,9 +81,7 @@ namespace AZ
                 Containers::Scene scene;
                 Import::ManifestImportRequestHandler manifestHandler;
                 manifestHandler.LoadAsset(
-                    scene, sourceAssetPath,
-                    Uuid::CreateNull(),
-                    Events::AssetImportRequest::RequestingApplication::AssetProcessor);
+                    scene, sourceAssetPath, Uuid::CreateNull(), Events::AssetImportRequest::RequestingApplication::AssetProcessor);
 
                 // Search for the ImportGroup. If it's there, get the new import settings. If not, we'll just use the defaults.
                 size_t count = scene.GetManifest().GetEntryCount();
@@ -105,16 +103,39 @@ namespace AZ
 
                 m_sceneWrapper->Clear();
 
+                AZStd::string filePath = context.GetInputDirectory();
+                AZStd::string extension = AZ::IO::Path(filePath).Extension().String();
+                AZStd::to_lower(extension);
+
+                auto* registry = ImportContextRegistryInterface::Get();
+                if (registry)
+                {
+                    m_contextProvider.reset(registry->SelectImportProvider(extension));
+                }
+                else
+                {
+                    AZ_Error("SceneBuilder", false, "ImportContextRegistry interface is not available.");
+                    return Events::ProcessingResult::Failure;
+                }
+
+                if (!m_contextProvider)
+                {
+                    AZ_Error("SceneBuilder", false, "Cannot pick Import Context for file: %s", filePath.c_str());
+                    return Events::ProcessingResult::Failure;
+                }
+
+                AZ_TracePrintf(
+                    "SceneBuilder",
+                    "Using '%s' Import Context Provider for file: %s",
+                    m_contextProvider->GetImporterName().data(),
+                    filePath.c_str());
+                m_sceneWrapper = m_contextProvider->CreateSceneWrapper();
                 if (!m_sceneWrapper->LoadSceneFromFile(context.GetInputDirectory().c_str(), importSettings))
                 {
                     return Events::ProcessingResult::Failure;
                 }
 
                 m_sceneSystem->Set(m_sceneWrapper.get());
-                if (!azrtti_istypeof<AssImpSDKWrapper::AssImpSceneWrapper>(m_sceneWrapper.get()))
-                {
-                    return Events::ProcessingResult::Failure;
-                }
 
                 if (ConvertScene(context.GetScene()))
                 {
@@ -134,28 +155,27 @@ namespace AZ
                     return false;
                 }
 
-                const AssImpSDKWrapper::AssImpSceneWrapper* assImpSceneWrapper = azrtti_cast <AssImpSDKWrapper::AssImpSceneWrapper*>(m_sceneWrapper.get());
+                AZStd::pair<SDKScene::SceneWrapperBase::AxisVector, int32_t> upAxisAndSign = m_sceneWrapper->GetUpVectorAndSign();
 
-                AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpSceneWrapper->GetUpVectorAndSign();
-
-                const AZ::Aabb& aabb = assImpSceneWrapper->GetAABB();
+                const AZ::Aabb& aabb = m_sceneWrapper->GetAABB();
                 scene.SetSceneDimension(aabb.GetExtents());
-                scene.SetSceneVertices(assImpSceneWrapper->GetVerticesCount());
+                scene.SetSceneVertices(m_sceneWrapper->GetVerticesCount());
 
                 if (upAxisAndSign.second <= 0)
                 {
-                    AZ_TracePrintf(SceneAPI::Utilities::ErrorWindow, "Negative scene orientation is not a currently supported orientation.");
+                    AZ_TracePrintf(
+                        SceneAPI::Utilities::ErrorWindow, "Negative scene orientation is not a currently supported orientation.");
                     return false;
                 }
                 switch (upAxisAndSign.first)
                 {
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::X:
+                case SDKScene::SceneWrapperBase::AxisVector::X:
                     scene.SetOriginalSceneOrientation(Containers::Scene::SceneOrientation::XUp);
                     break;
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Y:
+                case SDKScene::SceneWrapperBase::AxisVector::Y:
                     scene.SetOriginalSceneOrientation(Containers::Scene::SceneOrientation::YUp);
                     break;
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z:
+                case SDKScene::SceneWrapperBase::AxisVector::Z:
                     scene.SetOriginalSceneOrientation(Containers::Scene::SceneOrientation::ZUp);
                     break;
                 default:
@@ -191,84 +211,82 @@ namespace AZ
                         continue;
                     }
 
-                    AssImpNodeEncounteredContext sourceNodeEncountered(scene, newNode, *assImpSceneWrapper, *m_sceneSystem, nodeNameMap, *azrtti_cast<AZ::AssImpSDKWrapper::AssImpNodeWrapper*>(node.m_node.get()));
+                    auto sourceNodeEncountered = m_contextProvider->CreateNodeEncounteredContext(
+                        scene, newNode, *m_sceneSystem, nodeNameMap, *m_sceneWrapper, *(node.m_node));
                     Events::ProcessingResultCombiner nodeResult;
-                    nodeResult += Events::Process(sourceNodeEncountered);
+                    nodeResult += Events::Process(*sourceNodeEncountered);
 
                     // If no importer created data, we still create an empty node that may eventually contain a transform
-                    if (sourceNodeEncountered.m_createdData.empty())
+                    if (sourceNodeEncountered->m_createdData.empty())
                     {
-                        AZ_Assert(nodeResult.GetResult() != Events::ProcessingResult::Success,
+                        AZ_Assert(
+                            nodeResult.GetResult() != Events::ProcessingResult::Success,
                             "Importers returned success but no data was created");
                         AZStd::shared_ptr<DataTypes::IGraphObject> nullData(nullptr);
-                        sourceNodeEncountered.m_createdData.emplace_back(nullData);
+                        sourceNodeEncountered->m_createdData.emplace_back(nullData);
                         nodeResult += Events::ProcessingResult::Success;
                     }
 
                     // Create single node since only one piece of graph data was created
-                    if (sourceNodeEncountered.m_createdData.size() == 1)
+                    if (sourceNodeEncountered->m_createdData.size() == 1)
                     {
-                        AZ_Assert(nodeResult.GetResult() != Events::ProcessingResult::Ignored,
+                        AZ_Assert(
+                            nodeResult.GetResult() != Events::ProcessingResult::Ignored,
                             "An importer created data, but did not return success");
                         if (nodeResult.GetResult() == Events::ProcessingResult::Failure)
                         {
                             AZ_TracePrintf(Utilities::ErrorWindow, "One or more importers failed to create data.");
                         }
 
-                        AssImpSceneDataPopulatedContext dataProcessed(sourceNodeEncountered,
-                            sourceNodeEncountered.m_createdData[0], nodeName.c_str());
-                        Events::ProcessingResult result = AddDataNodeWithContexts(dataProcessed);
+                        auto dataProcessed = m_contextProvider->CreateSceneDataPopulatedContext(
+                            *sourceNodeEncountered, sourceNodeEncountered->m_createdData[0], nodeName.c_str());
+                        Events::ProcessingResult result = AddDataNodeWithContexts(*dataProcessed);
                         if (result != Events::ProcessingResult::Failure)
                         {
-                            newNode = dataProcessed.m_currentGraphPosition;
+                            newNode = dataProcessed->m_currentGraphPosition;
                         }
                     }
                     // Create an empty parent node and place all data under it. The remaining
                     // tree will be built off of this as the logical parent
                     else
                     {
-                        AZ_Assert(nodeResult.GetResult() != Events::ProcessingResult::Ignored,
+                        AZ_Assert(
+                            nodeResult.GetResult() != Events::ProcessingResult::Ignored,
                             "%i importers created data, but did not return success",
-                            sourceNodeEncountered.m_createdData.size());
+                            sourceNodeEncountered->m_createdData.size());
                         if (nodeResult.GetResult() == Events::ProcessingResult::Failure)
                         {
                             AZ_TracePrintf(Utilities::ErrorWindow, "One or more importers failed to create data.");
                         }
 
                         size_t offset = nodeName.length();
-                        for (size_t i = 0; i < sourceNodeEncountered.m_createdData.size(); ++i)
+                        for (size_t i = 0; i < sourceNodeEncountered->m_createdData.size(); ++i)
                         {
                             nodeName += '_';
                             nodeName += AZStd::to_string(aznumeric_cast<AZ::u64>(i + 1));
 
-                            Containers::SceneGraph::NodeIndex subNode =
-                                scene.GetGraph().AddChild(newNode, nodeName.c_str());
+                            Containers::SceneGraph::NodeIndex subNode = scene.GetGraph().AddChild(newNode, nodeName.c_str());
                             AZ_Assert(subNode.IsValid(), "Failed to create new scene sub node");
-                            AssImpSceneDataPopulatedContext dataProcessed(sourceNodeEncountered,
-                                sourceNodeEncountered.m_createdData[i], nodeName);
-                            dataProcessed.m_currentGraphPosition = subNode;
-                            AddDataNodeWithContexts(dataProcessed);
+                            auto dataProcessed = m_contextProvider->CreateSceneDataPopulatedContext(
+                                *sourceNodeEncountered, sourceNodeEncountered->m_createdData[i], nodeName);
+                            dataProcessed->m_currentGraphPosition = subNode;
+                            AddDataNodeWithContexts(*dataProcessed);
 
                             // Remove the temporary extension again.
                             nodeName.erase(offset, nodeName.length() - offset);
                         }
                     }
 
-                    AZ_Assert(nodeResult.GetResult() == Events::ProcessingResult::Success,
+                    AZ_Assert(
+                        nodeResult.GetResult() == Events::ProcessingResult::Success,
                         "No importers successfully added processed scene data.");
-                    AZ_Assert(newNode != node.m_parent,
-                        "Failed to update current graph position during data processing.");
+                    AZ_Assert(newNode != node.m_parent, "Failed to update current graph position during data processing.");
 
                     int childCount = node.m_node->GetChildCount();
                     for (int i = 0; i < childCount; ++i)
                     {
                         const std::shared_ptr<SDKNode::NodeWrapper> nodeWrapper = node.m_node->GetChild(i);
-                        auto assImpNodeWrapper = azrtti_cast<AssImpSDKWrapper::AssImpNodeWrapper*>(nodeWrapper.get());
-
-                        AZ_Assert(assImpNodeWrapper, "Child node is not the expected AssImpNodeWrapper type");
-
-                        std::shared_ptr<AssImpSDKWrapper::AssImpNodeWrapper> child = std::make_shared<AssImpSDKWrapper::AssImpNodeWrapper>(assImpNodeWrapper->GetAssImpNode());
-                        if (child)
+                        if (auto child = nodeWrapper)
                         {
                             nodes.emplace(AZStd::move(child), newNode);
                         }
@@ -277,13 +295,10 @@ namespace AZ
                     nodes.pop();
                 };
 
-                Events::ProcessingResult result = Events::Process<AssImpFinalizeSceneContext>(scene, *assImpSceneWrapper, *m_sceneSystem, nodeNameMap);
-                if (result == Events::ProcessingResult::Failure)
-                {
-                    return false;
-                }
-
-                return true;
+                auto finalizeSceneContext =
+                    m_contextProvider->CreateFinalizeSceneContext(scene, *m_sceneSystem, *m_sceneWrapper, nodeNameMap);
+                Events::ProcessingResult finalizeResult = Events::Process(*finalizeSceneContext);
+                return finalizeResult != Events::ProcessingResult::Failure;
             }
 
             void SceneImporter::SanitizeNodeName(AZStd::string& nodeName) const

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.h
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneImporter.h
@@ -8,14 +8,16 @@
 
 #pragma once
 
-#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <SceneAPI/SDKWrapper/SceneWrapper.h>
+#include <SceneAPI/SceneBuilder/ImportContextRegistryManager.h>
+#include <SceneAPI/SceneBuilder/ImportContexts/ImportContextProvider.h>
+#include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Components/LoadingComponent.h>
 #include <SceneAPI/SceneCore/Containers/SceneGraph.h>
 #include <SceneAPI/SceneCore/Events/ImportEventContext.h>
 #include <SceneAPI/SceneCore/Import/SceneImportSettings.h>
-#include <SceneAPI/SceneBuilder/SceneSystem.h>
-#include <SceneAPI/SDKWrapper/SceneWrapper.h>
 
 namespace AZ
 {
@@ -48,6 +50,8 @@ namespace AZ
 
                 AZStd::unique_ptr<SDKScene::SceneWrapperBase> m_sceneWrapper;
                 AZStd::shared_ptr<SceneSystem> m_sceneSystem;
+                AZStd::unique_ptr<ImportContextProvider> m_contextProvider {};
+                ImportContextRegistryManager m_contextRegistry;
             };
         } // namespace SceneBuilder
     } // namespace SceneAPI

--- a/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/SceneSystem.cpp
@@ -6,12 +6,11 @@
  *
  */
 
+#include "SceneWrapper.h"
+
 #include <AzCore/Math/Vector3.h>
 #include <SceneAPI/SceneBuilder/SceneSystem.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
-#include <SceneAPI/SDKWrapper/AssImpSceneWrapper.h>
-#include <SceneAPI/SDKWrapper/AssImpTypeConverter.h>
-#include <assimp/scene.h>
 
 
 namespace AZ
@@ -28,36 +27,9 @@ namespace AZ
 
         void SceneSystem::Set(const SDKScene::SceneWrapperBase* scene)
         {
-            // Get unit conversion factor to meter.
-            if (!azrtti_istypeof<AssImpSDKWrapper::AssImpSceneWrapper>(scene))
-            {
-                return;
-            }
+            m_unitSizeInMeters = scene->GetUnitSizeInMeters();
 
-            const AssImpSDKWrapper::AssImpSceneWrapper* assImpScene = azrtti_cast<const AssImpSDKWrapper::AssImpSceneWrapper*>(scene);
-
-            /* Check if metadata has information about "UnitScaleFactor" or "OriginalUnitScaleFactor". 
-             * This particular metadata is FBX format only. */
-            if (assImpScene->GetAssImpScene()->mMetaData->HasKey("UnitScaleFactor") ||
-                assImpScene->GetAssImpScene()->mMetaData->HasKey("OriginalUnitScaleFactor"))
-            {
-                // If either metadata piece is not available, the default of 1 will be used.
-                assImpScene->GetAssImpScene()->mMetaData->Get("UnitScaleFactor", m_unitSizeInMeters);
-                assImpScene->GetAssImpScene()->mMetaData->Get("OriginalUnitScaleFactor", m_originalUnitSizeInMeters);
-
-                /* Conversion factor for converting from centimeters to meters.
-                 * This applies to an FBX format in which the default unit is a centimeter. */
-                m_unitSizeInMeters = m_unitSizeInMeters * .01f;
-            }
-            else
-            {
-                // Some file formats (like DAE) embed the scale in the root transformation, so extract that scale from here.
-                auto rootTransform = 
-                    AssImpSDKWrapper::AssImpTypeConverter::ToTransform(assImpScene->GetAssImpScene()->mRootNode->mTransformation);
-                m_unitSizeInMeters = rootTransform.ExtractScale().GetMaxElement();
-            }
-
-            AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> upAxisAndSign = assImpScene->GetUpVectorAndSign();
+            AZStd::pair<SDKScene::SceneWrapperBase::AxisVector, int32_t> upAxisAndSign = scene->GetUpVectorAndSign();
 
             if (upAxisAndSign.second <= 0)
             {
@@ -65,10 +37,10 @@ namespace AZ
                 return;
             }
 
-            AZStd::pair<AssImpSDKWrapper::AssImpSceneWrapper::AxisVector, int32_t> frontAxisAndSign = assImpScene->GetFrontVectorAndSign();
+            AZStd::pair<SDKScene::SceneWrapperBase::AxisVector, int32_t> frontAxisAndSign = scene->GetFrontVectorAndSign();
 
-            if (upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Z &&
-                upAxisAndSign.first != AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Unknown)
+            if (upAxisAndSign.first != SDKScene::SceneWrapperBase::AxisVector::Z &&
+                upAxisAndSign.first != SDKScene::SceneWrapperBase::AxisVector::Unknown)
             {
                 AZ::Matrix4x4 currentCoordMatrix = AZ::Matrix4x4::CreateIdentity();
                 //(UpVector = +Z, FrontVector = +Y, CoordSystem = -X(RightHanded))
@@ -80,7 +52,7 @@ namespace AZ
 
                 switch (upAxisAndSign.first)
                 {
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::X: {
+                case SDKScene::SceneWrapperBase::AxisVector::X: {
                     if (frontAxisAndSign.second == 1)
                     {
                         currentCoordMatrix = AZ::Matrix4x4::CreateFromColumns(
@@ -99,7 +71,7 @@ namespace AZ
                     }
                 }
                 break;
-                case AssImpSDKWrapper::AssImpSceneWrapper::AxisVector::Y: {
+                case SDKScene::SceneWrapperBase::AxisVector::Y: {
                     if (frontAxisAndSign.second == 1)
                     {
                         currentCoordMatrix = AZ::Matrix4x4::CreateFromColumns(
@@ -120,7 +92,7 @@ namespace AZ
                 break;
                 }
                 AZ::Matrix4x4 adjustmatrix = targetCoordMatrix * currentCoordMatrix.GetInverseTransform();
-                m_adjustTransform.reset(new DataTypes::MatrixType(AssImpSDKWrapper::AssImpTypeConverter::ToTransform(adjustmatrix)));
+                m_adjustTransform.reset(new DataTypes::MatrixType(SDKScene::SceneTypeConverter::ToTransform(adjustmatrix)));
                 m_adjustTransformInverse.reset(new DataTypes::MatrixType(m_adjustTransform->GetInverseFull()));
             }
         }

--- a/Code/Tools/SceneAPI/SceneBuilder/scenebuilder_files.cmake
+++ b/Code/Tools/SceneAPI/SceneBuilder/scenebuilder_files.cmake
@@ -14,10 +14,18 @@ set(FILES
     SceneImporter.cpp
     SceneSystem.h
     SceneSystem.cpp
+    SceneBuilderSystemComponent.h
+    SceneBuilderSystemComponent.cpp
+    ImportContextRegistry.h
+    ImportContextRegistryManager.h
+    ImportContextRegistryManager.cpp
     ImportContexts/ImportContexts.h
     ImportContexts/ImportContexts.cpp
+    ImportContexts/ImportContextProvider.h
     ImportContexts/AssImpImportContexts.h
     ImportContexts/AssImpImportContexts.cpp
+    ImportContexts/AssImpImportContextProvider.h
+    ImportContexts/AssImpImportContextProvider.cpp
     Importers/Utilities/AssImpMeshImporterUtilities.h
     Importers/Utilities/AssImpMeshImporterUtilities.cpp
     Importers/Utilities/RenamedNodesMap.h


### PR DESCRIPTION
## What does this PR do?

We would like to use a different library for scene asset import yet still benefit from all offerings of the Scene API pipeline.
This PR reviews the interface between Scene API and AssImp and fixes the abstraction where it was leaking or non-existent.
It is an enabler for addition of different scene import libraries as Gems. By itself no functional changes were intended: all existing assets should be imported as before.


It removes references to AssImp specific code from the generic part of the SceneBuilder/SceneImporter.
It enhances SceneWrapperBase with additional methods that provide clear boundaries.
It refactors AssImp SDKWrapper and AssimpImportContext to be provided by AssimpImportContextProvider factory.
It uses Abstract Factory Pattern to decouple AssImp specific ImportContext from SceneImporter
It implements an ImportContextRegistry Interface for registration of additional ImportContextProviders

Note this target stabilization for convenience. Will be rebased against development after internal review

## How was this PR tested?

_Please describe any testing performed._
